### PR TITLE
[api.keyman.com] Add models to database and support /model api endpoint

### DIFF
--- a/script/hooks/keyboards-build-success.php
+++ b/script/hooks/keyboards-build-success.php
@@ -27,8 +27,8 @@
     fail('Invalid token');
   }
 
-  $log = "Triggered database build for keymanapp/keyboards\n".
-         "================================================\n\n";
+  $log = "Triggered database build for keymanapp/keyboards and keymanapp/lexical-models\n".
+         "=============================================================================\n\n";
   
   function build_log($message) {
     global $log;

--- a/script/model/model.php
+++ b/script/model/model.php
@@ -1,0 +1,68 @@
+<?php
+  require_once('../../tools/db/db.php');
+  require_once('../../tools/util.php');
+  
+  allow_cors();
+  json_response();
+  
+  header('Link: <https://api.keyman.com/schemas/model_info.distribution.json#>; rel="describedby"');
+
+  if(!isset($_REQUEST['id'])) {
+    fail('id parameter must be set');
+  }
+
+  $id = $_REQUEST['id'];
+  
+  /**
+    https://api.keyman.com/model/id
+    
+    Returns a single keyboard info for the model identified by `id`.
+    
+    https://api.keyman.com/schemas/model_info.distribution.json is JSON schema
+    
+    @param id    the identifier of the model to lookup
+  */
+  
+  if(($stmt = $mysql->prepare('SELECT model_info FROM t_model WHERE model_id = ?')) === false) {
+    fail("Failed to prepare query: {$mysql->error}\n");
+  }
+  
+  $stmt->bind_param("s", $id);
+    
+  if($stmt->execute()) {
+    $result = $stmt->get_result();
+    $data = $result->fetch_all();
+    if(count($data) == 0) {
+      fail('Model not found', 404);
+    }
+    $json = json_decode($data[0][0]);
+    $json->packageFilename = get_model_download_url($json->id, $json->version, $json->packageFilename);
+    $json->jsFilename = get_model_download_url($json->id, $json->version, $json->jsFilename);
+    
+    // Add the related models that are deprecated
+    
+    if(($stmt = $mysql->prepare('SELECT model_id FROM t_model_related WHERE related_model_id = ? AND deprecates <> 0')) === false) {
+      fail("Failed to prepare query: {$mysql->error}\n");
+    }
+    
+    $stmt->bind_param("s", $id);
+    
+    if($stmt->execute()) {
+      $result = $stmt->get_result();
+      $data = $result->fetch_all();
+      for($i = 0; $i < count($data); $i++) {
+        if(!isset($json->related)) {
+          $json->related = new stdClass();
+        }
+        $name = $data[$i][0];
+        $json->related->$name = array("deprecatedBy" => true);
+      }
+    }
+
+    echo json_encode($json, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);
+  } else {
+    fail("Failed to run: {$mysql->error}\n");
+  }      
+    
+  $mysql->close();
+?>

--- a/script/model/model_search.php
+++ b/script/model/model_search.php
@@ -1,0 +1,71 @@
+<?php
+  require_once('../../tools/db/db.php');
+  require_once('../../tools/util.php');
+  
+  allow_cors();
+  json_response();
+  
+  // TODO: We probably need to describe this with a schema
+  //header('Link: <https://api.keyman.com/schemas/model_info.distribution.json#>; rel="describedby"');
+
+  if(!isset($_REQUEST['q'])) {
+    fail('q parameter must be set');
+  }
+
+  $q = $_REQUEST['q'];
+  
+  /**
+    https://api.keyman.com/model?q=search
+    
+    Returns search results for the models matching `search`.
+    
+    @param search    the search string
+  */
+  
+  if(($stmt = $mysql->prepare('CALL sp_model_search(?, ?, ?)')) === false) {
+    fail("Failed to prepare query: {$mysql->error}\n");
+  }
+  
+        
+  function RegexEscape($text) {
+    $result = '[[:<:]]';
+    for($i = 0; $i < strlen($text); $i++) {
+      if(ord($text[$i]) < 128) {
+        $result .= "\\" . $text[$i];
+      } else {
+        $result .= $text[$i];
+      }
+    }
+    return $result;
+  }
+
+  if(substr($q, 0, 3) == 'id:') {
+    $q = substr($q, 3);
+    $m = 0;
+  } else if(substr($q, 0, 6) == 'bcp47:') {
+    // Search on this BCP47 code only
+    $q = substr($q, 6);
+    $m = 2;
+  } else {
+    $m = 1;
+  }
+
+  $qr = RegexEscape($q);
+  $stmt->bind_param("ssi", $qr, $q, $m);
+    
+  if($stmt->execute()) {
+    $result = $stmt->get_result();
+    $data = $result->fetch_all(MYSQLI_ASSOC);
+
+    foreach($data as &$model) {
+      $model = json_decode($model['model_info']);
+      $model->packageFilename = get_model_download_url($model->id, $model->version, $model->packageFilename);
+      $model->jsFilename = get_model_download_url($model->id, $model->version, $model->jsFilename);
+      }
+    json_print($data);
+  } else {
+    fail("Failed to run: {$mysql->error}\n");
+  }      
+    
+  $mysql->close();
+?>

--- a/tools/db/build/build.php
+++ b/tools/db/build/build.php
@@ -4,6 +4,7 @@
   require_once(dirname(__FILE__).'/../servervars.php');
   require_once('build_standards_data_script.php');
   require_once('build_keyboards_script.php');
+  require_once('build_models_script.php');
 
   function BuildDatabase($do_force) {
     global $mysqldb;
@@ -16,8 +17,12 @@
     $builder = new build_keyboards_sql();
     $builder->execute($data_path, $do_force) || fail("Unable to build keyboards data scripts");
 
+    $builder = new build_models_sql();
+    $builder->execute($data_path, $do_force) || fail("Unable to build lexical models data scripts");
+
     sqlrun(dirname(__FILE__)."/search.sql");
     sqlrun(dirname(__FILE__)."/search-queries.sql");
+    sqlrun(dirname(__FILE__)."/model-queries.sql");
     sqlrun(dirname(__FILE__)."/legacy-queries.sql");
     sqlrun("${data_path}language-subtag-registry.sql", $mysqldb);
     sqlrun("${data_path}iso639-3.sql", $mysqldb);
@@ -26,6 +31,7 @@
     sqlrun("${data_path}ethnologue_country_codes.sql", $mysqldb);
     sqlrun("${data_path}ethnologue_language_index.sql", $mysqldb);
     sqlrun("${data_path}keyboards.sql", $mysqldb);
+    sqlrun("${data_path}models.sql", $mysqldb);
     sqlrun(dirname(__FILE__)."/search-prepare-data.sql", $mysqldb);
     
     return true;

--- a/tools/db/build/build_models_script.php
+++ b/tools/db/build/build_models_script.php
@@ -128,7 +128,7 @@ END;
           $minKeymanVersion1 = $matches[1];
           $minKeymanVersion2 = $matches[2];
         } else {
-          $minKeymanVersion1 = 9;
+          $minKeymanVersion1 = 12;
           $minKeymanVersion2 = 0;
         }
 

--- a/tools/db/build/build_models_script.php
+++ b/tools/db/build/build_models_script.php
@@ -1,0 +1,330 @@
+<?php  
+  require_once('common.php');
+  
+  class build_models_sql {
+    
+    private $models_path, $cache_path;
+    
+    function execute($data_root, $do_force) {    
+      $this->models_path = $data_root . '/model_info/';
+      $this->cache_path = $data_root;
+      $this->force = $do_force;
+      
+      if(!is_dir($this->cache_path)) {
+        mkdir($this->cache_path, 0777, true) || fail("Unable to create folder " . $this->cache_path);
+      }
+      
+      if(!is_dir($this->models_path)) {
+        mkdir($this->models_path, 0777, true) || fail("Unable to create folder " . $this->models_path);
+      }
+
+      cache(URI_MODEL_INFO_ZIP, $this->cache_path . 'model_info.zip', 60 * 60 * 24 * 7, $this->force) || fail("Unable to download model_info.zip");
+      
+      $this->unzip() || fail("Unable to extract model_info.zip");
+      
+      if(($v = $this->build()) === false) 
+        fail("Unable to build models.sql");
+      file_put_contents($this->cache_path . "models.sql", $v) || fail("Unable to write models.sql to " . $this->cache_path);
+      
+      return true;
+    }
+
+    /**
+      Build a SQL script to insert model_info data into the database
+    */
+
+    private $models = array();
+    private $link;
+    
+    function unzip() {
+      $zip = new ZipArchive();
+      if(!$zip->open($this->cache_path . 'model_info.zip', 0)) 
+        return false;
+      
+      $result = $zip->extractTo($this->models_path);
+      $result |= $zip->close();
+      
+      return $result;
+    }
+
+    /**
+      Search through all folders under models_path to find .model_info files to
+      import into the database
+    */
+    function build() {
+      $this->link = new mysqli();
+
+      if(empty($this->models_path)) {
+        return false;
+      }
+      
+      $files = glob($this->models_path . '*.model_info');
+      foreach($files as $file) {
+        if(!$this->process_file($file)) {
+          return false;
+        }
+      }
+      
+      return 
+        $this->generate_model_inserts() .
+        $this->generate_model_language_inserts() .
+        $this->generate_model_link_inserts() .
+        $this->generate_model_related_inserts();
+    }
+    
+    /**
+      Loads a .model_info file, parses it into the 
+      models array
+    */
+    function process_file($file) {
+      if(($data = file_get_contents($file)) === false) {
+        return false;
+      }
+      
+      $model = json_decode($data);
+      $model->json = $data;
+      
+      array_push($this->models, $model);     
+      return true;
+    }
+    
+    /**
+      Generate an SQL script to insert entries in to the t_model table
+    */
+    function generate_model_inserts() {
+      $result = <<<END
+        INSERT t_model (
+          model_id, 
+          name, 
+          author_name, 
+          author_email, 
+          description, 
+          license, 
+          last_modified, 
+          version,
+
+          min_keyman_version,
+          min_keyman_version_1,
+          min_keyman_version_2,
+          
+          package_filename,
+          package_filesize,
+          js_filename,
+          js_filesize,
+
+          is_rtl,
+          
+          includes_fonts,
+          
+          model_info
+        ) VALUES
+END;
+
+      $comma = '';
+      foreach($this->models as $model) {
+        $isRTL = isset($model->isRTL) && $model->isRTL;
+        
+        if(isset($model->minKeymanVersion) && preg_match('/^(\d+)\.(\d+)/', $model->minKeymanVersion, $matches)) {
+          $minKeymanVersion1 = $matches[1];
+          $minKeymanVersion2 = $matches[2];
+        } else {
+          $minKeymanVersion1 = 9;
+          $minKeymanVersion2 = 0;
+        }
+
+        $includesFonts = isset($model->packageIncludes) && in_array('fonts', $model->packageIncludes);
+        
+        $result .= <<<END
+$comma
+          ({$this->sqlv($model, 'id')},
+          {$this->sqlv($model, 'name')},
+          {$this->sqlv($model, 'authorName')},
+          {$this->sqlv($model, 'authorEmail')},
+          {$this->sqlv($model, 'description')},
+          {$this->sqlv($model, 'license')},
+          {$this->sqld($model, 'lastModifiedDate')},
+          {$this->sqlv($model, 'version')},
+          
+          {$this->sqlv($model, 'minKeymanVersion')},
+          $minKeymanVersion1,
+          $minKeymanVersion2,
+    
+          {$this->sqlv($model, 'packageFilename')},
+          {$this->sqli($model, 'packageFileSize')},
+          {$this->sqlv($model, 'jsFilename')},
+          {$this->sqli($model, 'jsFileSize')},
+
+          {$this->sqlb($isRTL)},
+    
+          {$this->sqlb($includesFonts)},
+
+          {$this->sqlv($model, 'json')})
+END;
+        $comma=',';
+      }
+
+      if($comma == '') return ''; // no entries found
+      return $result . ";\n";
+    }
+    
+    /**
+      Generate an SQL script to insert entries in to the t_model_language table
+    */
+    function generate_model_language_inserts() {
+      $result = <<<END
+        INSERT t_model_language (
+          model_id, 
+          bcp47, 
+          language_id,
+          region_id,
+          script_id
+        ) VALUES
+END;
+
+      $comma = '';
+      foreach($this->models as $model) {
+        foreach($model->languages as $id) {
+          $this->parse_bcp47($id, $lang, $region, $script);
+          $result .= <<<END
+$comma
+              ({$this->sqlv($model, 'id')},
+              {$this->sqlv(null, $id)},
+              {$this->sqlv(null, $lang)},
+              {$this->sqlv(null, $region)},
+              {$this->sqlv(null, $script)})
+END;
+          $comma = ',';
+        }
+      }
+      
+      if($comma == '') return ''; // no entries found
+      return $result . ";\n";
+    }
+
+    /**
+      Generate an SQL script to insert entries in to the t_model_link table
+    */
+    function generate_model_link_inserts() {
+      $result = <<<END
+        INSERT t_model_link (
+          model_id, 
+          url, 
+          name
+        ) VALUES
+END;
+
+      $comma = '';
+      foreach($this->models as $model) {
+        if(!isset($model->links)) continue;
+        foreach($model->links as $link) {
+          $result .= <<<END
+$comma
+          ({$this->sqlv($model, 'id')},
+          {$this->sqlv($link, 'url')},
+          {$this->sqlv($link, 'name')})
+END;
+          $comma = ',';
+        }
+      }
+      
+      if($comma == '') return ''; // no entries found
+      return $result . ";\n";
+    }
+
+    /**
+      Generate an SQL script to insert entries in to the t_model_related table
+    */
+    function generate_model_related_inserts() {
+      $result = <<<END
+        INSERT t_model_related (
+          model_id, 
+          related_model_id, 
+          deprecates
+        ) VALUES
+END;
+
+      $comma = '';
+      foreach($this->models as $model) {
+        if(!isset($model->related)) continue;
+        $relatedobj = get_object_vars($model->related);
+        foreach($relatedobj as $id => $model) {
+          $deprecates = isset($related->deprecates) && $related->deprecates;
+          $result .= <<<END
+$comma
+          ({$this->sqlv($model, 'id')},
+          {$this->sqlv(null, $id)},
+          {$this->sqlb($deprecates)})
+END;
+          $comma = ',';
+        }
+      }
+      
+      if($comma == '') return ''; // no entries found
+      return $result . ";\n";
+    }
+    
+    /**
+      Safe-quotes a SQL string
+    */
+    function sqlv($o, $s) {
+      if($o !== null) {
+        if(isset($o->$s)) $s = $o->$s; 
+        else return 'null';
+      }
+      if($s === null) return 'null';
+      
+      $v = strpos($s, "\0");
+      if($v !== FALSE) {
+        $s = substr($s, 0, strpos($s, "\0"));
+      }
+      $s = iconv("UTF-8", "UTF-8//IGNORE", $s); // Strip invalid UTF-8 characters
+      //return "'" . mysql_real_escape_string($s) . "'";
+      return 
+        "'" . 
+        str_replace(["'",   "\"",   "\r",  "\n",  "\b",  "\t"], 
+                    ["\\'", "\\\"", "\\r", "\\n", "\\b", "\\t"],  
+                    str_replace("\\", "\\\\", $s) ) . 
+        "'";
+    }
+
+    /**
+      Safe-quotes a SQL date
+    */
+    function sqld($o, $s) {
+      if(isset($o->$s)) $s = $o->$s; 
+      else return 'null';
+      if($s === null) return 'null';
+      $s = substr($s, 0, 19);
+      return $this->sqlv(null, $s);
+    }
+    
+    function sqli($o, $s) {
+      if(isset($o->$s)) $s = $o->$s; 
+      else return 'null';
+      
+      if(!is_numeric($s)) die('Expecting numeric $s');
+      return $s;
+    }
+    
+    function sqlb($b) {
+      return $b ? '1' : '0';
+    }
+    
+    function parse_bcp47($bcp47, &$lang, &$region, &$script) {
+      $lang = null;
+      $region = null;
+      $script = null;
+      
+      // RegEx from https://stackoverflow.com/questions/7035825/regular-expression-for-a-language-tag-as-defined-by-bcp47, https://stackoverflow.com/a/34775980/1836776
+      $re = preg_match("/^(?<grandfathered>(?:en-GB-oed|i-(?:ami|bnn|default|enochian|hak|klingon|lux|mingo|navajo|pwn|t(?:a[oy]|su))|sgn-(?:BE-(?:FR|NL)|CH-DE))|(?:art-lojban|cel-gaulish|no-(?:bok|nyn)|zh-(?:guoyu|hakka|min(?:-nan)?|xiang)))|(?:(?<language>(?:[A-Za-z]{2,3}(?:-(?<extlang>[A-Za-z]{3}(?:-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(?:-(?<script>[A-Za-z]{4}))?(?:-(?<region>[A-Za-z]{2}|[0-9]{3}))?(?:-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(?:-(?<extension>[0-9A-WY-Za-wy-z](?:-[A-Za-z0-9]{2,8})+))*)(?:-(?<privateUse>x(?:-[A-Za-z0-9]{1,8})+))?$/Di", $bcp47, $matches);
+      if($re === FALSE) {
+        return false;
+      }
+      
+      if(isset($matches['language'])) $lang = $matches['language'];
+      if(isset($matches['region'])) $region = $matches['region'];
+      if(isset($matches['script'])) $script = $matches['script'];
+      return true;
+    }
+  }
+?>

--- a/tools/db/build/model-queries.sql
+++ b/tools/db/build/model-queries.sql
@@ -1,0 +1,38 @@
+USE keyboards;
+
+/*
+ sp_model_search
+*/
+
+DROP PROCEDURE IF EXISTS sp_model_search;
+
+CREATE PROCEDURE sp_model_search (
+IN prmSearchRegex VARCHAR(2048),
+ IN prmSearchPlain VARCHAR(2048),
+ IN prmMatchType INT
+)
+READS SQL DATA
+BEGIN
+  SELECT
+    m.model_info
+    
+  FROM
+    t_model m
+  WHERE
+    (
+      prmMatchType = 0 AND
+      m.model_id = prmSearchPlain
+    ) OR (
+      prmMatchType = 1 AND (
+        m.model_id REGEXP prmSearchRegex OR
+        m.name REGEXP prmSearchRegex OR
+        m.description REGEXP prmSearchRegex
+      )
+    ) OR (
+      prmMatchType = 2 AND (
+        EXISTS (SELECT * FROM t_model_language ml WHERE ml.model_id = m.model_id AND ml.language_id = prmSearchPlain)
+      )
+    )
+  ORDER BY
+    m.name;
+END;

--- a/tools/db/build/search.sql
+++ b/tools/db/build/search.sql
@@ -24,13 +24,16 @@ CREATE TABLE IF NOT EXISTS t_script (
   name varchar(64)
 );
 
-/*
+/*====================================================================
+
  Keyboard data, unpacked from keyboard_info json for searching.
  Original .keyboard_info is stored in the keyboard_info column so
  we are not reconstructing the json from the data on each query. This
  also ensures we do not lose data if the keyboard_info format is
  extended in the future.
-*/
+
+====================================================================*/
+
 CREATE TABLE IF NOT EXISTS t_keyboard (
   keyboard_id varchar(256) not null primary key,
   name varchar(256),
@@ -107,6 +110,84 @@ CREATE TABLE IF NOT EXISTS t_keyboard_related (
   
   foreign key (keyboard_id) references t_keyboard (keyboard_id)
 );
+
+/*====================================================================
+
+ Model data, unpacked from model_info json for searching.
+ Original .model_info is stored in the model_info column so
+ we are not reconstructing the json from the data on each query. This
+ also ensures we do not lose data if the model_info format is
+ extended in the future.
+
+====================================================================*/
+
+CREATE TABLE IF NOT EXISTS t_model (
+  model_id varchar(256) not null primary key,
+  name varchar(256),
+  author_name varchar(256),
+  author_email varchar(256),
+  description text,
+  license varchar(32),
+  last_modified date,
+
+  version varchar(64),
+  min_keyman_version varchar(64),
+  min_keyman_version_1 int,
+  min_keyman_version_2 int,
+  
+  package_filename varchar(256),
+  package_filesize int,
+  js_filename varchar(256),
+  js_filesize int,
+
+  is_rtl bit,
+  
+  includes_fonts bit,
+   
+  model_info json
+);
+
+/*
+ A language entry for a given model. If there is a 
+ matching language + region + script, then these will be populated,
+ but the bcp47 column is the master identifier for the language entry.
+ For example, the language_id may be qxx for an invented language.
+*/
+CREATE TABLE IF NOT EXISTS t_model_language (
+  model_id varchar(256),
+  bcp47 varchar(64), 
+  language_id varchar(3),
+  region_id char(2),
+  script_id char(4),
+  description varchar(256), /* use when bcp47 is broader than lang+reg+scr? */
+    
+  foreign key (model_id) references t_model (model_id)
+  /*foreign key (language_id) references t_language (language_id),
+  foreign key (region_id) references t_region (region_id),
+  foreign key (script_id) references t_script (script_id)*/
+);
+
+CREATE TABLE IF NOT EXISTS t_model_link (
+  model_id varchar(256),
+  url varchar(1024),
+  name varchar(256),
+  
+  foreign key (model_id) references t_model (model_id)
+);
+
+CREATE TABLE IF NOT EXISTS t_model_related (
+  model_id varchar(256),
+  related_model_id varchar(256), /* we don't use a fk constraint because the related model may not exist here */
+  deprecates bit,
+  
+  foreign key (model_id) references t_model (model_id)
+);
+
+/*====================================================================
+
+Standards Data
+
+====================================================================*/
 
 CREATE TABLE IF NOT EXISTS t_iso639_3 (
   Id      char(3) NOT NULL,  /* The three-letter 639-3 identifier*/

--- a/tools/db/servervars.php
+++ b/tools/db/servervars.php
@@ -4,4 +4,5 @@
   $mysqlhost=$_SERVER['api_keyman_com_mysql_host'];
   $mysqldb="keyboards";
   define('URI_KEYBOARD_INFO_ZIP', $_SERVER['api_keyman_com_keyboard_info_zip']);
+  define('URI_MODEL_INFO_ZIP', $_SERVER['api_keyman_com_model_info_zip']);
 ?>

--- a/tools/util.php
+++ b/tools/util.php
@@ -7,7 +7,7 @@
     header("HTTP/1.0 $code Fail: $s");
     if($is_json_response) {
       $error = array("message" => $s);
-      /*if(isset($mysql)) { <-- enable this on test sites if you are debugging mysql issues
+      /*if(isset($mysql)) { // <-- enable this on test sites if you are debugging mysql issues
         $error['mysql'] = $mysql->error;
       }*/
       if(!empty($log)) {
@@ -57,6 +57,10 @@
   
   function get_site_url_downloads() {
     return 'https://downloads.keyman.com';
+  }
+
+  function get_model_download_url($id, $version, $filename) {
+    return get_site_url_downloads() . "/models/{$id}/{$version}/{$filename}";
   }
 
 ?>

--- a/web.config
+++ b/web.config
@@ -28,6 +28,18 @@
           <action type="Rewrite" url="/script/keyboard/keyboard.php?id={R:1}" />
         </rule>
 
+        <!-- Rewrites for /script folder: /model -->
+
+        <rule name="/model?q=..." stopProcessing="true">
+          <match url="^model(/)?$" />
+          <action type="Rewrite" url="/script/model/model_search.php" appendQueryString="true" />
+        </rule>
+
+        <rule name="/model" stopProcessing="true">
+          <match url="^model/(.*)$" />
+          <action type="Rewrite" url="/script/model/model.php?id={R:1}" />
+        </rule>
+
         <!-- Rewrites for /script folder: /version -->
 
         <rule name="/version/platform/level" stopProcessing="true">


### PR DESCRIPTION
# Searching for models
## BCP 47 search

api.keyman.com/model?q=bcp47:km,en-AU will return all models for Khmer and Australian English. Note that the API should return models for en as well as en-AU; the consumer of the API should determine which it wants to present to the user. A given model may be registered for en-US and en in order to be available as a fallback for other English queries.

After installing a language and/or keyboard, this will be the search pattern used by Keyman apps.

**Implemented 2019-03-01**:
* q=bcp47:code - for all models that list that single BCP47 code explicitly.

**To do**:
* q=bcp47:code,code - multiple bcp47 codes
* q=bcp47:lang-region - matching on lang as well as lang-region

## Generic searches

api.keyman.com/model?q=nrc will return all models that match the search string nrc. This will search against text fields in the metadata, including id, name, description.

**Implemented 2019-03-01**:
* q=search - for any models that match that search string
Searching with the unified search API
api.keyman.com/search?q=amharic will add a new section, models. The format will match that of the standalone model search.

**To do**:
* Implement addition of models section

## Querying a single model
api.keyman.com/model/sil.km (canonical) or api.keyman.com/model?q=id:sil.km (also works, but returns the result in an array) will return a JSON format structure that mirrors that of the .model_info file. We will not support querying for older versions of models initially; the model information returned will always be for the latest current version. (Older versions will remain on the server; they just won't be searchable).

When a single model is queried, the result will be an object, not a single object in an array.

**Implemented 2019-03-01**:
* /model/id
* /model?q=id:id

## Querying for model updates

api.keyman.com/model?q=id:sil.km,nrc.en will return an array of model info that includes the latest version for each model. Deprecation can be handled using the deprecatedBy relation in the .model_info format.

**To do**:
* Implement multiple models

Per https://docs.google.com/document/d/1uBV5-MTJvtOlRc1r9qhv4MEFBAI4dyOjdocs3M1TL88/edit#