### PR TITLE
Make 'version' property optional in package.json schema

### DIFF
--- a/schemas/package/1.1.0/package.json
+++ b/schemas/package/1.1.0/package.json
@@ -275,7 +275,6 @@
       "required": [
         "name",
         "id",
-        "version",
         "languages"
       ]
     }

--- a/schemas/readme.MD
+++ b/schemas/readme.MD
@@ -6,7 +6,7 @@
 Documentation at https://help.keyman.com/developer/cloud/keyboard_info
 
 New versions should be deployed to
-- **keymanapp/keyman/windows/src/global/inst/keyboard_info**
+- **keymanapp/keyman/windows/src/global/inst/data/keyboard_info**
 - **keymanapp/keyboards/tools**
 - **keymanapp/keyboards-starter/tools**
 

--- a/schemas/readme.MD
+++ b/schemas/readme.MD
@@ -5,8 +5,8 @@
 
 Documentation at https://help.keyman.com/developer/cloud/keyboard_info
 
-New versions should be deployed to 
-- **keymanapp/keyman/windows/src/global/inst/keyboard_info** 
+New versions should be deployed to
+- **keymanapp/keyman/windows/src/global/inst/keyboard_info**
 - **keymanapp/keyboards/tools**
 - **keymanapp/keyboards-starter/tools**
 
@@ -70,7 +70,7 @@ Documentation at https://help.keyman.com/developer/10.0/reference/file-types/met
 # package.json version history
 
 ## 2019-01-31 1.1.0
-* Add lexicalModels properties
+* Add lexicalModels properties (note: `version` is optional and currently unused)
 
 ## 2018-02-13 1.0.2
 * Add rtl property for keyboard layouts
@@ -121,8 +121,8 @@ Documentation at https://help.keyman.com/developer/cloud/
 
 Documentation at https://help.keyman.com/developer/cloud/model_info
 
-New versions should be deployed to 
-- **keymanapp/keyman/windows/src/global/inst/model_info** 
+New versions should be deployed to
+- **keymanapp/keyman/windows/src/global/inst/model_info**
 - **keymanapp/lexical-models/tools**
 
 ## 2019-01-31 1.0 beta
@@ -134,7 +134,7 @@ New versions should be deployed to
 
 * visualkeyboard.dtd
 
-XML Document Type Defintion for the .kvks file format. Previously, this was 
+XML Document Type Defintion for the .kvks file format. Previously, this was
 at http://tavultesoft.com/keymandev/visualkeyboard.dtd.
 
 ## 2019-08-20


### PR DESCRIPTION
This doesn't increment the version number, as the metadata was in a pre-release version. However, instead of removing the `version` field entirely, I've made it optional so that schema validation for existing packages does not fail. This may not be 100% ideal but is a non-breaking change to the schema.

See also keymanapp/keyman#2164.