### PR TITLE
fix: case-sensitive BCP 47 subtags are breaking API search and consistency

### DIFF
--- a/tools/db/build/build_keyboards_script.php
+++ b/tools/db/build/build_keyboards_script.php
@@ -369,9 +369,9 @@ END;
         return false;
       }
       
-      if(isset($matches['language'])) $lang = $matches['language'];
-      if(isset($matches['region'])) $region = $matches['region'];
-      if(isset($matches['script'])) $script = $matches['script'];
+      if(isset($matches['language'])) $lang = strtolower($matches['language']);
+      if(isset($matches['region'])) $region = strtolower($matches['region']);
+      if(isset($matches['script'])) $script = strtolower($matches['script']);
       return true;
     }
   }

--- a/tools/db/build/build_models_script.php
+++ b/tools/db/build/build_models_script.php
@@ -325,9 +325,9 @@ END;
         return false;
       }
       
-      if(isset($matches['language'])) $lang = $matches['language'];
-      if(isset($matches['region'])) $region = $matches['region'];
-      if(isset($matches['script'])) $script = $matches['script'];
+      if(isset($matches['language'])) $lang = strtolower($matches['language']);
+      if(isset($matches['region'])) $region = strtolower($matches['region']);
+      if(isset($matches['script'])) $script = strtolower($matches['script']);
       return true;
     }
   }

--- a/tools/db/build/build_standards_data_script.php
+++ b/tools/db/build/build_standards_data_script.php
@@ -182,16 +182,20 @@ END;
         return; 
       }
       if(isset($row['Scope']) && $row['Scope'] == 'private-use') return;
-      
+
+      // We'll work with all subtags as lower case for search etc
+      if(!isset($row['Subtag'])) return;
+      $subtag = strtolower($row['Subtag']);
+
       switch($row['Type']) {
       case 'language':
-        $this->languages[$row['Subtag']] = $row['Description'];
+        $this->languages[$subtag] = $row['Description'];
         break;
       case 'script':
-        $this->scripts[$row['Subtag']] = $row['Description'];
+        $this->scripts[$subtag] = $row['Description'];
         break;
       case 'region':
-        $this->regions[$row['Subtag']] = $row['Description'];
+        $this->regions[$subtag] = $row['Description'];
         break;
       }
     }


### PR DESCRIPTION
A recently uploaded keyboard had a lowercase 'fr-ca' instead of 'fr-CA' and this impacted the sort order and merge of results in such a way as to result in repeated keys, breaking the JSON standard:

```
[…
  {name: "French (Canada)", id: "fr-CA", region: 4, keyboards: [,…]},
  {name: "French (Canada)", id: "fr-ca", region: 4,…},
  {name: "French (Canada)", id: "fr-CA", region: 4,…},
…]
```

This change reduces all BCP 47 tags to lowercase in the database.