### PR TITLE
fix: spurious warnings filling logs

### DIFF
--- a/script/legacy/legacy20.php
+++ b/script/legacy/legacy20.php
@@ -287,6 +287,10 @@
       return;
     }
     
+    if(!isset($keyboard_info->languages->$lang)) {
+      return;
+    }
+
     $jsonlanguage = $keyboard_info->languages->$lang;
       
     // fontToObject -- oskFont, font

--- a/script/legacy/legacy30.php
+++ b/script/legacy/legacy30.php
@@ -291,6 +291,10 @@
       return;
     }
     
+    if(!isset($keyboard_info->languages->$lang)) {
+      return;
+    }
+
     $jsonlanguage = $keyboard_info->languages->$lang;
       
     // fontToObject -- oskFont, font

--- a/script/legacy/legacy40.php
+++ b/script/legacy/legacy40.php
@@ -406,6 +406,10 @@ function removeKeyboardsFromLanguages($res) {
       return;
     }
     
+    if(!isset($keyboard_info->languages->$lang)) {
+      return;
+    }
+
     $jsonlanguage = $keyboard_info->languages->$lang;
       
     // fontToObject -- oskFont, font

--- a/tools/onlineupdate.php
+++ b/tools/onlineupdate.php
@@ -39,9 +39,13 @@
     private function BuildKeymanDesktopVersionResponse($InstalledVersion) {
       $platform = $this->platform;
       
-      $DownloadVersions = @json_decode(file_get_contents(get_site_url_downloads() . "/api/version/$this->platform/2.0"));
-      if($DownloadVersions === NULL) {
+      $DownloadVersions = @file_get_contents(get_site_url_downloads() . "/api/version/$this->platform/2.0");
+      if($DownloadVersions === FALSE) {
         fail('Unable to retrieve version data from '.get_site_url_downloads(), 500);
+      }
+      $DownloadVersions = @json_decode($DownloadVersions);
+      if($DownloadVersions === NULL) {
+        fail('Unable to decode version data from '.get_site_url_downloads(), 500);
       }
       
       if(!isset($DownloadVersions->$platform)) {
@@ -113,9 +117,14 @@
     
     private function BuildKeyboardResponse($id, $version, $appVersion) {
       $platform = $this->platform;
-      $KeyboardDownload = json_decode(file_get_contents(get_site_url_api()."/keyboard/$id"));
-      if($KeyboardDownload === NULL) {
+      $KeyboardDownload = @file_get_contents(get_site_url_api()."/keyboard/$id");
+      if($KeyboardDownload === FALSE) {
         // not found
+        return FALSE;
+      }
+      $KeyboardDownload = @json_decode($KeyboardDownload);
+      if($KeyboardDownload === NULL) {
+        // invalid json
         return FALSE;
       }
       
@@ -165,7 +174,11 @@
     }
     
     private function BuildKeyboardDownloadPath($id, $version) {
-      $data = @json_decode(file_get_contents(get_site_url_downloads() . "/api/keyboard/$id"));
+      $data = @file_get_contents(get_site_url_downloads() . "/api/keyboard/$id");
+      if($data === FALSE) {
+        return FALSE;
+      }
+      $data = @json_decode($data);
       if($data === NULL) {
         return FALSE;
       }


### PR DESCRIPTION
Fixes #22.
Fixes #23.

Online Update Check was causing logs to fill up due to
file_get_contents emitting a warning on a 400 or 404.

The legacy KeymanWeb APIs were emitting notices when looking up
fonts and examples for languages that were not set.