### PR TITLE
fix: all keyboards lookup performance

### DIFF
--- a/script/legacy/legacy40.php
+++ b/script/legacy/legacy40.php
@@ -308,10 +308,7 @@ function getKeyboardInfo($keyboard, $languageid, $allKeyboardLanguages) {
     // Load languages
 
     $jslanguages = array();
-    $languages = [];
-    foreach($allKeyboardLanguages as $akl) {
-      if($akl['keyboard_id'] == $keyboard['keyboard_id']) array_push($languages, $akl);
-    }
+    $languages = $allKeyboardLanguages[$keyboard['keyboard_id']];
     $output_languageid = translateLanguageIdToOutputFormat($languageid);
     foreach($languages as $language) {
       $langid = translateLanguageIdToOutputFormat($language['bcp47']);

--- a/script/legacy/legacy_db.php
+++ b/script/legacy/legacy_db.php
@@ -60,7 +60,7 @@
     $data = $result->fetch_all(MYSQLI_ASSOC);
     $result->free();
     $stmt->close();
-    return $data;
+    return DB_ExplodeByKeyboardID($data);
   }
 
   function DB_LoadAllKeyboardLanguages($id) {
@@ -74,9 +74,22 @@
     $data = $result->fetch_all(MYSQLI_ASSOC);
     $result->free();
     $stmt->close();
+    return DB_ExplodeByKeyboardID($data);
+  }
 
-    DB_LogStats("DB_LoadAllKeyboardLanguages($id)");
-    return $data;
+  function DB_ExplodeByKeyboardID($data) {
+    $result = [];
+    $keyboard_id = null;
+    foreach($data as $row) {
+      if($row['keyboard_id'] != $keyboard_id) {
+        if(isset($languages)) $result[$keyboard_id] = $languages;
+        $languages = [];
+        $keyboard_id = $row['keyboard_id'];
+      }
+      array_push($languages, $row);
+    }
+    if(isset($languages)) $result[$keyboard_id] = $languages;
+    return $result;
   }
 
   function DB_LoadLanguages($id) {

--- a/script/legacy/legacy_db.php
+++ b/script/legacy/legacy_db.php
@@ -8,7 +8,7 @@
     $stmt->prepare($s) || fail('Could not prepare statement');
     return $stmt;
   }
-    
+
   function DB_LoadKeyboards($id) {
     global $version1, $version2;
     $stmt = new_query('CALL sp_legacy10_keyboard(?, ?, ?)');
@@ -22,7 +22,7 @@
     $stmt->close();
     return $data;
   }
-  
+
   function DB_LoadKeyboardLanguages($id) {
     $stmt = new_query('CALL sp_legacy10_keyboard_languages(?)');
     $stmt->bind_param('s', $id) || fail('Could not bind parameters for sp_legacy10_keyboard_languages');
@@ -35,7 +35,7 @@
     $stmt->close();
     return $data;
   }
-    
+
   function DB_LoadKeyboardsForLanguage($id) {
     global $version1, $version2;
     $stmt = new_query('CALL sp_legacy10_keyboards_for_language(?, ?, ?)');
@@ -49,7 +49,36 @@
     $stmt->close();
     return $data;
   }
-      
+
+  function DB_LoadAllKeyboardLanguagesByLanguage($id) {
+    $stmt = new_query('CALL sp_legacy10_languages_for_keyboards_for_language(?)');
+    $stmt->bind_param('s', $id) || fail('Could not bind parameters for sp_legacy10_languages_for_keyboards_for_language');
+    $stmt->execute() || fail('Unable to execute sp_legacy10_languages_for_keyboards_for_language load');
+    if(($result = $stmt->get_result()) === FALSE) {
+      fail('Unable to get query results');
+    }
+    $data = $result->fetch_all(MYSQLI_ASSOC);
+    $result->free();
+    $stmt->close();
+    return $data;
+  }
+
+  function DB_LoadAllKeyboardLanguages($id) {
+    if(empty($id)) $id = null;
+    $stmt = new_query('CALL sp_legacy10_all_keyboard_languages(?)');
+    $stmt->bind_param('s', $id) || fail('Could not bind parameters for sp_legacy10_all_keyboard_languages');
+    $stmt->execute() || fail('Unable to execute sp_legacy10_all_keyboard_languages load');
+    if(($result = $stmt->get_result()) === FALSE) {
+      fail('Unable to get query results');
+    }
+    $data = $result->fetch_all(MYSQLI_ASSOC);
+    $result->free();
+    $stmt->close();
+
+    DB_LogStats("DB_LoadAllKeyboardLanguages($id)");
+    return $data;
+  }
+
   function DB_LoadLanguages($id) {
     if(empty($id)) $id = null;
     global $version1, $version2;


### PR DESCRIPTION
Addresses issues with performance for looking up all keyboards, e.g. as
used by KeymanWeb:
https://api.keyman.com/cloud/4.0/keyboards?jsonp=keyman.register&languageidtype=bcp47&version=12.0.103&timerid=6

This would result in about 630 separate queries, one for the list of
keyboards, and one for each keyboard returned to get the list of
languages associated with the keyboards. The fix reduces this to
two queries: one for the keyboards, and one for the languages.

This appears to be correlated to a massive increase in data egress on
api.keyman.com MySQL database instance; while the queries themselves
amounted to about 1.3mb of data, each call would result in 80mb of
outbound traffic. This may be due to some configuration change on the
database as it has only arisen recently.

In any case, this change results in a significant performance
improvement and should mitigate the data usage immediately.

Note that the api.keyman.com endpoint is proxied by CloudFlare and you
may want to test against keymanapi.azurewebsites.net to observe the
performance before and after.