### PR TITLE
fix: Improve performance of legacy/languages

### DIFF
--- a/script/legacy/legacy30.php
+++ b/script/legacy/legacy30.php
@@ -102,15 +102,21 @@
   function getLanguages($id, $keyboardid) {
     global $device;
 
+    $languages = DB_LoadLanguages_0($id);
+    $keyboards_0 = DB_LoadLanguages_0_Keyboards($id);
+    $keyboards = [];
+    foreach($keyboards_0 as $row) {
+      $keyboards[$row['keyboard_id']] = $row;
+    }
 
-    $languages = DB_LoadLanguages($id);
-    
     $LastID = '';
     $res = array();
     foreach($languages as $language) {
       if(isKeyboardFiltered($language['keyboard_id'])) {
         continue;
       }
+
+      $keyboard = $keyboards[$language['keyboard_id']];
 
       $langid = translateLanguageIdToOutputFormat($language['bcp47']);
       if($LastID != $langid) {
@@ -129,13 +135,13 @@
       
       $reskbd = array(
         'id' => $language['keyboard_id'], 
-        'name' => $language['name'], 
-        'filename' => getKeyboardURI($language['keyboard_id'], $language['version']),
-        'lastModified' => dateFormat($language['last_modified']),
-        'version' => $language['version'],
-        'fileSize' => $language['js_filesize']);
+        'name' => $keyboard['name'], 
+        'filename' => getKeyboardURI($keyboard['keyboard_id'], $keyboard['version']),
+        'lastModified' => dateFormat($keyboard['last_modified']),
+        'version' => $keyboard['version'],
+        'fileSize' => $keyboard['js_filesize']);
       
-      $keyboard_info = json_decode($language['keyboard_info']);
+      $keyboard_info = json_decode($keyboard['keyboard_info']);
 
       // TODO: minVersion, maxVersion
       //if(!empty($language->MinKeymanWebVersion)) $reskbd['minVersion'] = $language->MinKeymanWebVersion;
@@ -143,7 +149,7 @@
             
       addFontAndExample($reskbd, $language['bcp47'], $keyboard_info, $device);
       
-      if($language['is_rtl']) {
+      if($keyboard['is_rtl']) {
         $reskbd['rtl'] = true;
       }
       
@@ -174,8 +180,9 @@
 *   
 * @param CRM_CloudKeyboardVersion $keyboard
 * @param string $languageid
+* @param CRM_AllKeyboardLanguages $allKeyboardLanguages
 */
-  function getKeyboardInfo($keyboard, $languageid) {
+  function getKeyboardInfo($keyboard, $languageid, $allKeyboardLanguages) {
     global $device;
     
     $jskeyboard = array(
@@ -196,7 +203,7 @@
     
     // Load languages
     $jslanguages = array();
-    $languages = DB_LoadKeyboardLanguages($keyboard['keyboard_id']);
+    $languages = $allKeyboardLanguages[$keyboard['keyboard_id']];
     foreach($languages as $language) {
       $item = array(
         'id' => translateLanguageIdToOutputFormat($language['bcp47']), 
@@ -215,21 +222,25 @@
     if(empty($languageid) && empty($keyboardid)) {
       // All keyboards, root level
       $keyboards = DB_LoadKeyboards(null);
+      $allKeyboardLanguages = DB_LoadAllKeyboardLanguages(null);
     } else if(empty($languageid)) {
       // Specific keyboard, root level -- return single keyboard
       $keyboards = DB_LoadKeyboards($keyboardid);
+      $allKeyboardLanguages = DB_LoadAllKeyboardLanguages($keyboardid);
       if(sizeof($keyboards) > 0) {
-        return getKeyboardInfo($keyboards[0], '');
+        return getKeyboardInfo($keyboards[0], '', $allKeyboardLanguages);
       }
       fail('Keyboard not found', 404);
     } else if(empty($keyboardid)) {
       // Keyboards for specific language, child level
       $keyboards = DB_LoadKeyboardsForLanguage($languageid);
+      $allKeyboardLanguages = DB_LoadAllKeyboardLanguagesByLanguage($languageid);
     } else {
       // Specific keyboard, root level -- return single keyboard
       $keyboards = DB_LoadKeyboards($keyboardid);
+      $allKeyboardLanguages = DB_LoadAllKeyboardLanguages($keyboardid);
       if(sizeof($keyboards) > 0) {
-        return getKeyboardInfo($keyboards[0], $languageid);
+        return getKeyboardInfo($keyboards[0], $languageid, $allKeyboardLanguages);
       }
       fail("Keyboard not found", 404);
     }
@@ -240,7 +251,7 @@
       if(isKeyboardFiltered($keyboard['keyboard_id'])) {
         continue;
       }
-      $jskeyboard = getKeyboardInfo($keyboard, '');
+      $jskeyboard = getKeyboardInfo($keyboard, '', $allKeyboardLanguages);
       array_push($jskeyboards, $jskeyboard);
     }
 
@@ -291,6 +302,8 @@
       return;
     }
     
+    if(!isset($keyboard_info->languages->$lang)) return;
+
     $jsonlanguage = $keyboard_info->languages->$lang;
       
     // fontToObject -- oskFont, font

--- a/script/legacy/legacy30.php
+++ b/script/legacy/legacy30.php
@@ -109,14 +109,15 @@
       $keyboards[$row['keyboard_id']] = $row;
     }
 
+    $reslang = null;
+    $reskbds = null;
+
     $LastID = '';
     $res = array();
     foreach($languages as $language) {
       if(isKeyboardFiltered($language['keyboard_id'])) {
         continue;
       }
-
-      $keyboard = $keyboards[$language['keyboard_id']];
 
       $langid = translateLanguageIdToOutputFormat($language['bcp47']);
       if($LastID != $langid) {
@@ -133,6 +134,8 @@
         continue;
       }
       
+      $keyboard = $keyboards[$language['keyboard_id']];
+
       $reskbd = array(
         'id' => $language['keyboard_id'], 
         'name' => $keyboard['name'], 

--- a/script/legacy/legacy40.php
+++ b/script/legacy/legacy40.php
@@ -308,10 +308,7 @@ function getKeyboardInfo($keyboard, $languageid, $allKeyboardLanguages) {
     // Load languages
 
     $jslanguages = array();
-    $languages = [];
-    foreach($allKeyboardLanguages as $akl) {
-      if($akl['keyboard_id'] == $keyboard['keyboard_id']) array_push($languages, $akl);
-    }
+    $languages = $allKeyboardLanguages[$keyboard['keyboard_id']];
     $output_languageid = translateLanguageIdToOutputFormat($languageid);
     foreach($languages as $language) {
       $langid = translateLanguageIdToOutputFormat($language['bcp47']);

--- a/script/legacy/legacy40.php
+++ b/script/legacy/legacy40.php
@@ -152,8 +152,12 @@
   function getLanguages($id, $keyboardid) {
     global $device, $kmw;
 
-
-    $languages = DB_LoadLanguages($id);
+    $languages = DB_LoadLanguages_0($id);
+    $keyboards_0 = DB_LoadLanguages_0_Keyboards($id);
+    $keyboards = [];
+    foreach($keyboards_0 as $row) {
+      $keyboards[$row['keyboard_id']] = $row;
+    }
 
     $reslang = null;
     $reskbds = null;
@@ -164,6 +168,8 @@
       if(isKeyboardFiltered($language['keyboard_id'])) {
         continue;
       }
+
+      $keyboard = $keyboards[$language['keyboard_id']];
 
       $langid = translateLanguageIdToOutputFormat($language['bcp47']);
       if($LastID != $langid) {
@@ -187,20 +193,20 @@
 
       $reskbd = array(
         'id' => $language['keyboard_id'],
-        'name' => $language['name'],
-        'filename' => getKeyboardURI($language['keyboard_id'], $language['version']),
-        'version' => $language['version']
+        'name' => $keyboard['name'],
+        'filename' => getKeyboardURI($keyboard['keyboard_id'], $keyboard['version']),
+        'version' => $keyboard['version']
       );
 
-      $keyboard_info = json_decode($language['keyboard_info']);
+      $keyboard_info = json_decode($keyboard['keyboard_info']);
 
       if(isset($keyboard_info->sourcePath)) {
         $reskbd['source'] = GITHUB_ROOT . $keyboard_info->sourcePath;
       }
 
       if(!$kmw) {
-        $reskbd['lastModified'] = dateFormat($language['last_modified']);
-        $reskbd['fileSize'] = $language['js_filesize'];
+        $reskbd['lastModified'] = dateFormat($keyboard['last_modified']);
+        $reskbd['fileSize'] = $keyboard['js_filesize'];
       }
 
 

--- a/script/legacy/legacy40.php
+++ b/script/legacy/legacy40.php
@@ -169,8 +169,6 @@
         continue;
       }
 
-      $keyboard = $keyboards[$language['keyboard_id']];
-
       $langid = translateLanguageIdToOutputFormat($language['bcp47']);
       if($LastID != $langid) {
         if(isset($reslang) && !empty($reslang)) {
@@ -190,6 +188,8 @@
       if(!empty($keyboardid) && $language['keyboard_id'] != $keyboardid) {
         continue;
       }
+
+      $keyboard = $keyboards[$language['keyboard_id']];
 
       $reskbd = array(
         'id' => $language['keyboard_id'],

--- a/script/legacy/legacy40.php
+++ b/script/legacy/legacy40.php
@@ -225,7 +225,7 @@
 
       addFontAndExample($reskbd, $language['bcp47'], $keyboard_info, $device);
 
-      if((!$kmw) && $language['is_rtl']) {
+      if((!$kmw) && $keyboard['is_rtl']) {
         $reskbd['rtl'] = true;
       }
 

--- a/script/legacy/legacy_db.php
+++ b/script/legacy/legacy_db.php
@@ -106,4 +106,37 @@
     $stmt->close();
     return $data;
   }
+
+  /* Optimised version of DB_LoadLanguages -- splits keyboard and language queries so we have less data */
+
+  function DB_LoadLanguages_0($id) {
+    if(empty($id)) $id = null;
+    global $version1, $version2;
+    $stmt = new_query('CALL sp_legacy10_language_0(?, ?, ?)');
+    $stmt->bind_param('sii', $id, $version1, $version2) || fail('Could not bind parameters for sp_legacy10_language_0');
+    $stmt->execute() || fail('Unable to execute sp_legacy10_language_0 load');
+    if(($result = $stmt->get_result()) === FALSE) {
+      fail('Unable to get query results');
+    }
+    $data = $result->fetch_all(MYSQLI_ASSOC);
+    $result->free();
+    $stmt->close();
+    return $data;
+  }
+
+  function DB_LoadLanguages_0_Keyboards($id) {
+    if(empty($id)) $id = null;
+    global $version1, $version2;
+    $stmt = new_query('CALL sp_legacy10_language_0_keyboards(?, ?, ?)');
+    $stmt->bind_param('sii', $id, $version1, $version2) || fail('Could not bind parameters for sp_legacy10_language_0_keyboards');
+    $stmt->execute() || fail('Unable to execute sp_legacy10_language_0_keyboards load');
+    if(($result = $stmt->get_result()) === FALSE) {
+      fail('Unable to get query results');
+    }
+    $data = $result->fetch_all(MYSQLI_ASSOC);
+    $result->free();
+    $stmt->close();
+    return $data;
+  }
+
 ?>

--- a/script/legacy/legacy_db.php
+++ b/script/legacy/legacy_db.php
@@ -60,7 +60,7 @@
     $data = $result->fetch_all(MYSQLI_ASSOC);
     $result->free();
     $stmt->close();
-    return $data;
+    return DB_ExplodeByKeyboardID($data);
   }
 
   function DB_LoadAllKeyboardLanguages($id) {
@@ -74,9 +74,22 @@
     $data = $result->fetch_all(MYSQLI_ASSOC);
     $result->free();
     $stmt->close();
+    return DB_ExplodeByKeyboardID($data);
+  }
 
-    DB_LogStats("DB_LoadAllKeyboardLanguages($id)");
-    return $data;
+  function DB_ExplodeByKeyboardID($data) {
+    $result = [];
+    $keyboard_id = null;
+    foreach($data as $row) {
+      if($row['keyboard_id'] != $keyboard_id) {
+        if(isset($languages)) $result[$keyboard_id] = $languages;
+        $languages = [];
+        $keyboard_id = $row['keyboard_id'];
+      }
+      array_push($languages, $row);
+    }
+    if(isset($languages)) $result[$keyboard_id] = $languages;
+    return $result;
   }
 
   function DB_LoadLanguages($id) {

--- a/tools/db/build/legacy-queries.sql
+++ b/tools/db/build/legacy-queries.sql
@@ -226,3 +226,92 @@ BEGIN
     kl.bcp47,
     k.keyboard_id;
 END;
+
+DROP PROCEDURE IF EXISTS sp_legacy10_language_0;
+
+CREATE PROCEDURE sp_legacy10_language_0 (
+ IN bcp47 VARCHAR(256),
+ IN minKeymanVersion1 INT,
+ IN minKeymanVersion2 INT
+)
+READS SQL DATA
+BEGIN
+  SELECT
+    kl.keyboard_id,
+    kl.bcp47,
+    elc.CountryID region_id, -- see notes from sp_legacy10_keyboard_languages
+    ec.Area legacy_region,   -- see notes from sp_legacy10_keyboard_languages
+    CONCAT(
+      COALESCE(
+        elc.Name, li.Ref_Name, kl.bcp47),
+      COALESCE(
+        CONCAT(' (',s.name,', ',r.name,')'),
+        CONCAT(' (',r.name,')'),
+        CONCAT(' (',s.name,')'),
+        '')
+    ) language_name            -- see notes from sp_legacy10_keyboard_languages
+  FROM
+    t_keyboard k INNER JOIN
+    t_keyboard_language kl ON k.keyboard_id = kl.keyboard_id LEFT JOIN
+    -- This join is imperfect because we are ignoring the region part of the bcp47 tag, for now. We should join across that
+    -- and then prioritise that region.
+    t_iso639_3 li ON li.CanonicalId = kl.language_id  LEFT JOIN -- Join across normalised language id
+    t_ethnologue_language_codes elc ON li.Id = elc.LangID LEFT JOIN
+    t_ethnologue_country_codes ec ON elc.CountryID = ec.CountryID LEFT JOIN
+    t_region r ON kl.region_id = r.region_id LEFT JOIN
+    t_script s ON kl.script_id = s.script_id
+  WHERE
+    (kl.bcp47 = bcp47 OR bcp47 IS NULL) AND
+    (
+      k.min_keyman_version_1 < minKeymanVersion1 OR
+      (k.min_keyman_version_1 = minKeymanVersion1 AND k.min_keyman_version_2 <= minKeymanVersion2)
+    ) AND
+    (k.js_filename IS NOT NULL)
+  ORDER BY
+    COALESCE(elc.Name, li.Ref_Name, kl.bcp47),
+    kl.bcp47,
+    k.keyboard_id;
+END;
+
+DROP PROCEDURE IF EXISTS sp_legacy10_language_0_keyboards;
+
+CREATE PROCEDURE sp_legacy10_language_0_keyboards (
+ IN bcp47 VARCHAR(256),
+ IN minKeymanVersion1 INT,
+ IN minKeymanVersion2 INT
+)
+READS SQL DATA
+BEGIN
+  SELECT
+    k.keyboard_id,
+    k.version,
+    k.platform_android,
+    k.platform_ios,
+    k.platform_windows,
+    k.platform_web,
+    k.last_modified,
+    k.js_filename,
+    k.js_filesize,
+    k.is_rtl,
+    k.name,
+    k.legacy_id,
+    k.keyboard_info
+  FROM
+    t_keyboard k
+  WHERE
+    k.keyboard_id IN (
+      SELECT
+        kl.keyboard_id 
+      FROM
+        t_keyboard_language kl
+      WHERE
+        (kl.bcp47 = bcp47 OR bcp47 IS NULL)
+    ) AND
+    (
+      k.min_keyman_version_1 < minKeymanVersion1 OR
+      (k.min_keyman_version_1 = minKeymanVersion1 AND k.min_keyman_version_2 <= minKeymanVersion2)
+    ) AND
+    (k.js_filename IS NOT NULL)
+  ORDER BY
+    k.keyboard_id;
+END;


### PR DESCRIPTION
`getLanguages()` was also very slow in legacy30 and legacy40, for opposite
reason of the last commit: in this case everything was being returned in
one monolithic query which duplicated data heavy fields, resulting in a
70MB query result, which was transformed finally into a 270KB JSON result.

Splitting this query into 2 queries allowed for normalization of this data;
this query was also suffering from the same issue in legacy30.php as was
fixed in legacy40.php in #24, which creates a massive performance hit
(namely spurious Notices when looking up missing fonts/examples).