### PR TITLE
fix: add deprecated state for keyboards

### DIFF
--- a/schemas/keyboard_info.distribution/1.0.5/keyboard_info.distribution.json
+++ b/schemas/keyboard_info.distribution/1.0.5/keyboard_info.distribution.json
@@ -1,0 +1,8 @@
+{ 
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "allOf": [
+    { "$ref": "/keyboard_info.source/1.0.5/keyboard_info.source.json#/definitions/KeyboardInfo" },
+    { "required": [ "id", "name", "license", "languages", "lastModifiedDate", "platformSupport" ] }
+  ]
+}

--- a/schemas/keyboard_info.source/1.0.5/keyboard_info.source.json
+++ b/schemas/keyboard_info.source/1.0.5/keyboard_info.source.json
@@ -1,0 +1,170 @@
+{ 
+  "$schema": "http://json-schema.org/schema#",
+  "$ref": "#/definitions/KeyboardInfo",
+  
+  "definitions": {
+    "KeyboardInfo": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "authorName": { "type": "string" },
+        "authorEmail": { "type": "string", "format": "email" },
+        "description": { "type": "string" },
+        "license": { "type": "string", "enum": ["freeware", "shareware", "commercial", "mit", "other"] },
+        "languages": { "anyOf": [
+          { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+          { "$ref": "#/definitions/KeyboardLanguageInfo" }
+        ]},
+        "lastModifiedDate": { "type": "string", "format": "date-time" },
+        "links": { "type": "array", "items": { "$ref": "#/definitions/KeyboardLinkInfo" } },
+        "packageFilename": { "type": "string", "pattern": "\\.km[xp]$" },
+        "packageFileSize": { "type": "number" },
+        "jsFilename": { "type": "string", "pattern": "\\.js$" },
+        "jsFileSize": { "type": "number" },
+        "documentationFilename": { "type": "string", "pattern": "\\.(rtf|html?|pdf|txt)$" },
+        "documentationFileSize": { "type": "number" },
+        "isRTL": { "type": "boolean" },
+        "encodings": { "type": "array", "items": { "type": "string", "enum": ["ansi", "unicode"] }, "additionalItems": false },
+        "packageIncludes": { "type": "array", "items": { "type": "string", "enum": ["welcome", "documentation", "fonts", "visualKeyboard"] }, "additionalItems": false },
+        "version": { "type": "string" },
+        "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.0$" },
+        "helpLink": { "type": "string", "pattern": "^https://help\\.keyman\\.com/keyboard/" },
+        "platformSupport": { "$ref": "#/definitions/KeyboardPlatformInfo" },
+        "legacyId": { "type": "number" },
+        "sourcePath": { "type": "string", "pattern": "^(release|legacy|experimental)/.+/.+$" },
+        "related": { "type": "object", "patternProperties": { 
+          ".": { "$ref": "#/definitions/KeyboardRelatedInfo" }
+          },
+          "additionalProperties": false
+        },
+        "deprecated": { "type": "boolean" }
+      },
+      "required": [
+        "license", "languages"
+      ],
+      "additionalProperties": false
+    },
+  
+    "KeyboardLanguageInfo": {
+      "type": "object",
+      "patternProperties": {
+        ".": { "$ref": "#/definitions/KeyboardLanguageInfoItem" }
+      },
+      "additionalProperties": false
+    },
+    
+    "KeyboardLanguageInfoItem": {
+      "type": "object",
+      "properties": {
+        "font": { "$ref": "#/definitions/KeyboardFontInfo" },
+        "oskFont": { "$ref": "#/definitions/KeyboardFontInfo" },
+        "example": { "$ref": "#/definitions/KeyboardExampleInfo" }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    
+    "KeyboardFontInfo": {
+      "type": "object",
+      "properties": {
+        "family": { "type": "string" },
+        "source": { "anyOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "string" } }
+        ] },
+        "size": { "type": "string" }
+      },
+      "required": ["family", "source"],
+      "additionalProperties": false
+    },
+
+    "KeyboardExampleInfo": {
+      "type": "object",
+      "properties": {
+        "keys": { "anyOf": [ 
+          { "type": "string" },
+          { "type": "array", "items": { 
+            "anyOf": [
+              { "type": "string" },
+              { "$ref": "#/definitions/KeyboardExampleKeyInfo" }
+            ] }
+          }
+        ] },
+        "text": { "type": "string" },
+        "note": { "type": "string" }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    
+    "KeyboardExampleKeyInfo": {
+      "type": "object",
+      "properties": {
+        "key": { "type": "string", "enum": [
+          "K_SPACE",
+          "K_A", "K_B", "K_C", "K_D", "K_E", "K_F", "K_G", "K_H", "K_I", "K_J", "K_K", "K_L", "K_M",
+          "K_N", "K_O", "K_P", "K_Q", "K_R", "K_S", "K_T", "K_U", "K_V", "K_W", "K_X", "K_Y", "K_Z",
+          "K_1", "K_2", "K_3", "K_4", "K_5", "K_6", "K_7", "K_8", "K_9", "K_0",
+          "K_BKQUOTE", "K_HYPHEN", "K_EQUAL", "K_LBRKT", "K_RBRKT", "K_BKSLASH", "K_COLON",
+          "K_QUOTE", "K_COMMA", "K_PERIOD", "K_SLASH", 
+          "K_oE2", "K_BKSP", "K_TAB", "K_ENTER", "K_ESC",
+          "K_LEFT", "K_UP", "K_RIGHT", "K_DOWN", "K_PGUP", "K_PGDN", "K_HOME", "K_END", "K_INS", "K_DEL",
+          "K_F1", "K_F2", "K_F3", "K_F4", "K_F5", "K_F6", "K_F7", "K_F8", "K_F9", "K_F10", "K_F11", "K_F12",
+          "K_KP5", "K_NP0", "K_NP1", "K_NP2", "K_NP3", "K_NP4", "K_NP5", "K_NP6", "K_NP7", "K_NP8", "K_NP9",
+          "K_NPSTAR", "K_NPPLUS", "K_NPMINUS", "K_NPDOT", "K_NPSLASH",
+          "K_SEL", "K_PRINT", "K_EXEC", "K_HELP", "K_SEPARATOR",
+          "K_F13", "K_F14", "K_F15", "K_F16", "K_F17", "K_F18", "K_F19", "K_F20", "K_F21", "K_F22", "K_F23", "K_F24",
+          "K_KANJI?15", "K_KANJI?16", "K_KANJI?17", "K_KANJI?18", "K_KANJI?19", "K_KANJI?1C", "K_KANJI?1D", "K_KANJI?1E", "K_KANJI?1F",
+          "K_oE0", "K_oE1", "K_oE3", "K_oE4", "K_oE6", "K_oE9", "K_oEA", "K_oEB", "K_oEC", "K_oED", "K_oEE", "K_oEF",
+          "K_oF0", "K_oF1", "K_oF2", "K_oF3", "K_oF4", "K_oF5", "K_?00", "K_?05", "K_NPENTER",
+          "K_?06", "K_?07", "K_?0A", "K_?0B", "K_?0E", "K_?0F", "K_?1A", "K_?3A", "K_?3B", "K_?3C", "K_?3D", "K_?3E",
+          "K_?3F", "K_?40", "K_?5B", "K_?5C", "K_?5D", "K_?5E", "K_?5F", "K_?88", "K_?89", "K_?8A", "K_?8B", "K_?8C",
+          "K_?8D", "K_?8E", "K_?8F", "K_?92", "K_?94", "K_?95", "K_?96", "K_?97", "K_?98", "K_?99", "K_?9A", "K_?9B",
+          "K_?9C", "K_?9D", "K_?9E", "K_?9F", "K_?A0", "K_?A1", "K_?A2", "K_?A3", "K_?A4", "K_?A5", "K_?A6", "K_?A7",
+          "K_?A8", "K_?A9", "K_?AA", "K_?AB", "K_?AC", "K_?AD", "K_?AE", "K_?AF", "K_?B0", "K_?B1", "K_?B2", "K_?B3",
+          "K_?B4", "K_?B5", "K_?B6", "K_?B7", "K_?B8", "K_?B9", "K_?C1", "K_?C2", "K_?C3", "K_?C4", "K_?C5", "K_?C6",
+          "K_?C7", "K_?C8", "K_?C9", "K_?CA", "K_?CB", "K_?CC", "K_?CD", "K_?CE", "K_?CF", "K_?D0", "K_?D1", "K_?D2",
+          "K_?D3", "K_?D4", "K_?D5", "K_?D6", "K_?D7", "K_?D8", "K_?D9", "K_?DA", "K_oDF", "K_?E5", "K_?E7", "K_?E8",
+          "K_?F6", "K_?F7", "K_?F8", "K_?F9", "K_?FA", "K_?FB", "K_?FC", "K_?FD", "K_?FE", "K_?FF"
+        ] },
+        "modifiers": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["shift", "s", "ctrl", "c", "alt", "a", "left-ctrl", "lc", "right-ctrl", "rc", "left-alt", "la", "right-alt", "ra"] }
+        }
+      },
+      "required": ["key"],
+      "additionalProperties": false
+    },
+    
+    "KeyboardLinkInfo": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "url": { "type": "string" }
+      },
+      "required": ["name", "url"],
+      "additionalProperties": false
+    },
+    
+    "KeyboardPlatformInfo": {
+      "type": "object",
+      "patternProperties": {
+        "^(windows|macos|desktopWeb|ios|android|mobileWeb|linux)$": { "type": "string", "enum": ["dictionary", "full", "basic", "none"] }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    
+    "KeyboardRelatedInfo": {
+      "type": "object",
+      "properties": {
+        "deprecates": { "type": "boolean" },
+        "deprecatedBy": { "type": "boolean" },
+        "note": { "type": "string" }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/readme.MD
+++ b/schemas/readme.MD
@@ -12,6 +12,9 @@ New versions should be deployed to
 
 # .keyboard_info version history
 
+## 2018-11-26 1.0.5 stable
+* Add deprecated field - true if the keyboard is deprecated (generated at deployment time).
+
 ## 2018-11-26 1.0.4 stable
 * Add helpLink field - a link to a keyboard's help page on help.keyman.com if it exists.
 
@@ -37,6 +40,9 @@ New versions should be deployed to
 Documentation at https://help.keyman.com/developer/cloud/search
 
 # search version history
+
+## 2019-12-13 1.0.2
+* Added deprecated field for keyboard_info
 
 ## 2018-02-06 1.0.1
 * Added SearchCountry definition.

--- a/schemas/search/1.0.2/search.json
+++ b/schemas/search/1.0.2/search.json
@@ -7,7 +7,7 @@
       "type": "object",
       "properties": {
         "languages": { "type": "array", "items": { "$ref": "#/definitions/SearchLanguage" } },
-        "keyboards": { "type": "array", "items": { "$ref": "/keyboard_info.source/1.0.4/keyboard_info.source.json#/definitions/KeyboardInfo" } },
+        "keyboards": { "type": "array", "items": { "$ref": "/keyboard_info.source/1.0.5/keyboard_info.source.json#/definitions/KeyboardInfo" } },
         "countries": { "type": "array", "items": { "$ref": "#/definitions/SearchCountry" } },
         "rangematch": { "type": "string" }
       }

--- a/schemas/search/1.0/search.json
+++ b/schemas/search/1.0/search.json
@@ -7,7 +7,7 @@
       "type": "object",
       "properties": {
         "languages": { "type": "array", "items": { "$ref": "#/definitions/SearchLanguage" } },
-        "keyboards": { "type": "array", "items": { "$ref": "/keyboard_info.source.json#/definitions/KeyboardInfo" } },
+        "keyboards": { "type": "array", "items": { "$ref": "/keyboard_info.source/1.0.4/keyboard_info.source.json#/definitions/KeyboardInfo" } },
         "countries": { "type": "array" },
         "rangematch": { "type": "string" }
       }

--- a/schemas/web.config
+++ b/schemas/web.config
@@ -12,12 +12,12 @@
         
         <rule name="keyboard_info.distribution.json" enabled="true" stopProcessing="true">
           <match url="^keyboard_info\.distribution\.json$" ignoreCase="false" />
-          <action type="Rewrite" url="keyboard_info.distribution/1.0.4/keyboard_info.distribution.json" />
+          <action type="Rewrite" url="keyboard_info.distribution/1.0.5/keyboard_info.distribution.json" />
         </rule>
 
         <rule name="keyboard_info.source.json" enabled="true" stopProcessing="true">
           <match url="^keyboard_info\.source\.json$" ignoreCase="false" />
-          <action type="Rewrite" url="keyboard_info.source/1.0.4/keyboard_info.source.json" />
+          <action type="Rewrite" url="keyboard_info.source/1.0.5/keyboard_info.source.json" />
         </rule>
         
         <rule name="keyboard_json.json" enabled="true" stopProcessing="true">
@@ -42,7 +42,7 @@
 
         <rule name="search.json" enabled="true" stopProcessing="true">
           <match url="^search\.json$" ignoreCase="false" />
-          <action type="Rewrite" url="search/1.0.1/search.json" />
+          <action type="Rewrite" url="search/1.0.2/search.json" />
         </rule>
 
         <rule name="version.json" enabled="true" stopProcessing="true">

--- a/script/search/search.php
+++ b/script/search/search.php
@@ -356,7 +356,10 @@
       if(($result = $stmt->get_result()) === FALSE) fail('Unable to get search result for keyboard');
 
       while(($row = $result->fetch_assoc()) !== NULL) {
-        array_push($data, json_decode($row['keyboard_info']));
+        // Append 'deprecated' to the model data
+        $rowdata = json_decode($row['keyboard_info']);
+        if($row['deprecated']) $rowdata->deprecated = true;
+        array_push($data, $rowdata);
       }
       
       $result->free();

--- a/tools/db/.gitignore
+++ b/tools/db/.gitignore
@@ -1,1 +1,2 @@
 test.php
+localenv.php

--- a/tools/db/build/build.php
+++ b/tools/db/build/build.php
@@ -6,8 +6,18 @@
   require_once('build_keyboards_script.php');
   require_once('build_models_script.php');
 
+  function reportTime() {
+    global $report_last_time;
+    $new_time = microtime(true);
+    build_log("Timestamp: ".sprintf("%0.02f", ($new_time-$report_last_time)));
+    $report_last_time = $new_time;
+  }
+
   function BuildDatabase($do_force) {
     global $mysqldb;
+
+    global $report_last_time;
+    $report_last_time = microtime(true);
     
     $data_path = dirname(dirname(dirname(dirname(__FILE__)))) . "/.data/";
 
@@ -41,13 +51,14 @@
     $filename = basename($url);
     build_log("Downloading $filename");
     if(($data = file_get_contents($url)) === false) {
-      fail("Unable to download $url");
+      fail("Unable to download $url: $php_errormsg");
     }
     file_put_contents($filename, $data);
     return true;
   }
   
   function sqlrun($sql, $db = '') {
+    reportTime();
     build_log("Running $sql");
     global $mysqlhost, $mysqlpw, $mysqldb, $mysqluser;
     $s = file_get_contents($sql);
@@ -64,4 +75,3 @@
     $m->close();
   }
   
-?>

--- a/tools/db/build/build_keyboards_script.php
+++ b/tools/db/build/build_keyboards_script.php
@@ -22,6 +22,8 @@
         mkdir($this->keyboards_path, 0777, true) || fail("Unable to create folder " . $this->keyboards_path);
       }
 
+      reportTime();
+
       cache(URI_KEYBOARD_INFO_ZIP, $this->cache_path . 'keyboard_info.zip', 60 * 60 * 24 * 7, $this->force) || fail("Unable to download keyboard_info.zip");
       
       $this->unzip() || fail("Unable to extract keyboard_info.zip");
@@ -29,6 +31,8 @@
       if(($v = $this->build()) === false) 
         fail("Unable to build keyboards.sql");
       file_put_contents($this->cache_path . "keyboards.sql", $v) || fail("Unable to write keyboards.sql to " . $this->cache_path);
+
+      reportTime();
       
       return true;
     }

--- a/tools/db/build/build_models_script.php
+++ b/tools/db/build/build_models_script.php
@@ -22,6 +22,8 @@
         mkdir($this->models_path, 0777, true) || fail("Unable to create folder " . $this->models_path);
       }
 
+      reportTime();
+
       cache(URI_MODEL_INFO_ZIP, $this->cache_path . 'model_info.zip', 60 * 60 * 24 * 7, $this->force) || fail("Unable to download model_info.zip");
       
       $this->unzip() || fail("Unable to extract model_info.zip");
@@ -29,6 +31,8 @@
       if(($v = $this->build()) === false) 
         fail("Unable to build models.sql");
       file_put_contents($this->cache_path . "models.sql", $v) || fail("Unable to write models.sql to " . $this->cache_path);
+
+      reportTime();
       
       return true;
     }

--- a/tools/db/build/build_standards_data_script.php
+++ b/tools/db/build/build_standards_data_script.php
@@ -25,27 +25,39 @@
         mkdir($this->script_path, 0777, true) || fail("Unable to create folder {$this->script_path}");
       }
   
+      reportTime();
+
       if(($v = $this->build_sql_data_script_subtags()) === FALSE) {
         fail("Failed to build language subtag registry sql");
       }
       
       file_put_contents($this->script_path . "language-subtag-registry.sql", $v) || fail("Unable to write language-subtag-registry.sql to {$this->script_path}");
 
+      reportTime();
+
       if(!$this->cache_iso639_3_file(URI_ISO639_3_TAB, 'iso639-3.tab', 'iso639-3.sql', 't_iso639_3')) {
         fail("Failed to download iso639-3.tab");
       }
       
+      reportTime();
+
       if(!$this->cache_iso639_3_file(URI_ISO639_3_NAME_INDEX_TAB, 'iso639-3_Name_Index.tab', 'iso639-3-name-index.sql', 't_iso639_3_names')) {
         fail("Failed to download iso639-3.tab");
       }
+
+      reportTime();
 
       if(!$this->cache_ethnologue_language_index(ETHNOLOGUE_LANGUAGE_CODES_TAB, 'ethnologue_language_codes.tab', 'ethnologue_language_codes.sql', 't_ethnologue_language_codes')) {
         fail("Failed to download ethnologue_language_codes.tab");
       }
 
+      reportTime();
+
       if(!$this->cache_ethnologue_language_index(ETHNOLOGUE_COUNTRY_CODES_TAB, 'ethnologue_country_codes.tab', 'ethnologue_country_codes.sql', 't_ethnologue_country_codes')) {
         fail("Failed to download ethnologue_country_codes.tab");
       }
+
+      reportTime();
 
       if(!$this->cache_ethnologue_language_index(ETHNOLOGUE_LANGUAGE_INDEX_TAB, 'ethnologue_language_index.tab', 'ethnologue_language_index.sql', 't_ethnologue_language_index')) {
         fail("Failed to download ethnologue_language_index.tab");

--- a/tools/db/build/common.php
+++ b/tools/db/build/common.php
@@ -10,9 +10,20 @@
     if($local_force) $duration = 0;
     if(!file_exists($filename) || time()-filemtime($filename) > $duration) {
       echo "Downloading $url\n";
-      if(($file = @file_get_contents($url)) === FALSE) {
+      
+      // Create a stream
+      $opts = array(
+        'http'=>array(
+          'method'=>"GET",
+          'header'=>"User-Agent: api-keyman-com Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1\r\n"
+        )
+      );      
+
+      $context = stream_context_create($opts);      
+
+      if(($file = @file_get_contents($url, false, $context)) === FALSE) {
         if(!file_exists($filename)) {
-          echo "Failed to download $url\n"; //todo to stderr
+          echo "Failed to download $url: $php_errormsg\n"; //todo to stderr
           return false;
         }
       } else {
@@ -42,4 +53,3 @@
     }
     return rmdir($dirPath);
   }
-?>

--- a/tools/db/build/search-prepare-data.sql
+++ b/tools/db/build/search-prepare-data.sql
@@ -52,8 +52,8 @@ drop table t_pejorative_index;
 
 update t_keyboard 
   set deprecated = 1
-  where exists (select * from t_keyboard_related kr where kr.related_keyboard_id = t_keyboard.keyboard_id)
+  where exists (select * from t_keyboard_related kr where kr.related_keyboard_id = t_keyboard.keyboard_id);
 
 update t_model
   set deprecated = 1
-  where exists (select * from t_model_related mr where mr.related_model_id = t_model.model_id)
+  where exists (select * from t_model_related mr where mr.related_model_id = t_model.model_id);

--- a/tools/db/build/search-prepare-data.sql
+++ b/tools/db/build/search-prepare-data.sql
@@ -46,3 +46,14 @@ delete from t_ethnologue_language_index where nametype='LP' or nametype='DP';
 
 drop table t_pejorative_index;
 
+--
+-- Deprecated keyboards and models should be flagged as such in the t_keyboard/t_model data
+--
+
+update t_keyboard 
+  set deprecated = 1
+  where exists (select * from t_keyboard_related kr where kr.related_keyboard_id = t_keyboard.keyboard_id)
+
+update t_model
+  set deprecated = 1
+  where exists (select * from t_model_related mr where mr.related_model_id = t_model.model_id)

--- a/tools/db/build/search-queries.sql
+++ b/tools/db/build/search-queries.sql
@@ -38,6 +38,8 @@ BEGIN
     k.platform_ios,
     k.platform_android,
     k.platform_web,
+    k.platform_linux,
+    k.deprecated,
     k.keyboard_info
     
   FROM
@@ -62,6 +64,7 @@ BEGIN
       )
     )
   ORDER BY
+    k.deprecated ASC,
     k.is_unicode DESC,
     k.name;
 END;

--- a/tools/db/build/search.sql
+++ b/tools/db/build/search.sql
@@ -70,7 +70,9 @@ CREATE TABLE IF NOT EXISTS t_keyboard (
   platform_ios tinyint,
   platform_android tinyint,
   platform_web tinyint,
-  /*platform_linux tinyint,*/
+  platform_linux tinyint,
+
+  deprecated bit,
   
   keyboard_info json
 );
@@ -143,6 +145,8 @@ CREATE TABLE IF NOT EXISTS t_model (
   is_rtl bit,
   
   includes_fonts bit,
+
+  deprecated bit,
    
   model_info json
 );

--- a/tools/db/servervars.php
+++ b/tools/db/servervars.php
@@ -1,8 +1,10 @@
 <?php
-  $mysqlpw=$_SERVER['api_keyman_com_mysql_pw'];
-  $mysqluser=$_SERVER['api_keyman_com_mysql_user'];
-  $mysqlhost=$_SERVER['api_keyman_com_mysql_host'];
-  $mysqldb="keyboards";
+  if(file_exists(dirname(__FILE__) . '/localenv.php')) {
+    require_once(dirname(__FILE__) . '/localenv.php');
+  }
+  if(!isset($mysqlpw)) $mysqlpw=$_SERVER['api_keyman_com_mysql_pw'];
+  if(!isset($mysqluser)) $mysqluser=$_SERVER['api_keyman_com_mysql_user'];
+  if(!isset($mysqlhost)) $mysqlhost=$_SERVER['api_keyman_com_mysql_host'];
+  if(!isset($mysqldb)) $mysqldb="keyboards";
   define('URI_KEYBOARD_INFO_ZIP', $_SERVER['api_keyman_com_keyboard_info_zip']);
   define('URI_MODEL_INFO_ZIP', $_SERVER['api_keyman_com_model_info_zip']);
-?>

--- a/tools/util.php
+++ b/tools/util.php
@@ -4,7 +4,7 @@
   function fail($s, $code=400) {
     global $is_json_response, $mysql;
     global $log;
-    header("HTTP/1.0 $code Fail: $s");
+    header("HTTP/1.0 $code Failure");
     if($is_json_response) {
       $error = array("message" => $s);
       /*if(isset($mysql)) { // <-- enable this on test sites if you are debugging mysql issues
@@ -62,5 +62,3 @@
   function get_model_download_url($id, $version, $filename) {
     return get_site_url_downloads() . "/models/{$id}/{$version}/{$filename}";
   }
-
-?>


### PR DESCRIPTION
Backend changes relating to keymanapp/keyman.com#62

Adds deprecation state to the database and surfaces it 
in the keyboard search. This leads to a slight difference
in .keyboard_info and API data.

Fixes #5.
Fixes #7.
Fixes #29.

## TODO
- [x] Update schema to include deprecated field
- [x] Document changes to results
- [x] Test locally (I need to setup a local replication)