### PR TITLE
fix: add 13.0+ api endpoints

### DIFF
--- a/web.config
+++ b/web.config
@@ -133,30 +133,30 @@
           <action type="Rewrite" url="/script/hooks/keyboards-build-success.php?format=text/plain" />
         </rule>
 
-        <!-- Keyman Desktop 10.0, 11.0, 12.0 API endpoints -->
+        <!-- Keyman Desktop 10.0, 11.0, 12.0, etc API endpoints -->
         
         <rule name="desktop/10.0/update" stopProcessing="true">
-          <match url="^desktop/1[012]\.0/update(.*)" />
+          <match url="^desktop/[1-9][0-9]\.[0-9]/update(.*)" />
           <action type="Rewrite" url="/script/desktop/10.0/update/index.php{R:1}" />
         </rule>
 
         <rule name="desktop/10.0/exception" stopProcessing="true">
           <!-- Note: this endpoint is also used by developer -->
-          <match url="^desktop/1[012]\.0/exception(.*)" />
+          <match url="^desktop/[1-9][0-9]\.[0-9]/exception(.*)" />
           <action type="Rewrite" url="/script/desktop/10.0/exception/index.php{R:1}" />
         </rule>
 
-        <!-- Keyman Developer 10.0, 11.0, 12.0 API endpoints -->
+        <!-- Keyman Developer 10.0, 11.0, 12.0, etc API endpoints -->
 
         <rule name="developer/10.0/update" stopProcessing="true">
-          <match url="^developer/1[012]\.0/update(.*)" />
+          <match url="^developer/[1-9][0-9]\.[0-9]/update(.*)" />
           <action type="Rewrite" url="/script/developer/10.0/update/index.php{R:1}" />
         </rule>
 
-        <!-- Rewrites for 10.0, 11.0, 12.0 tavultesoft.com checks -->
+        <!-- Rewrites for 10.0, 11.0, 12.0, etc tavultesoft.com checks -->
 
         <rule name="Reverse Proxy for desktop/10.0/locale" stopProcessing="true">
-          <match url="^desktop/1[012]\.0/locale(.*)" />
+          <match url="^desktop/[1-9][0-9]\.[0-9]/locale(.*)" />
           <action type="Rewrite" url="https://secure.tavultesoft.com/prog/100/downloadlocales/all.php{R:1}" />
           <serverVariables>
             <set name="HTTP_X_UNPROXIED_URL" value="https://secure.tavultesoft.com/prog/100/downloadlocales/all.php{R:1}" />
@@ -166,7 +166,7 @@
           </serverVariables>          
         </rule>
         <rule name="Reverse Proxy for desktop/10.0/submitdiag" stopProcessing="true">
-          <match url="^desktop/1[012]\.0/submitdiag(.*)" />
+          <match url="^desktop/[1-9][0-9]\.[0-9]/submitdiag(.*)" />
           <action type="Rewrite" url="https://secure.tavultesoft.com/prog/submitdiag.php{R:1}" />
           <serverVariables>
             <set name="HTTP_X_UNPROXIED_URL" value="https://secure.tavultesoft.com/prog/submitdiag.php{R:1}" />
@@ -176,7 +176,7 @@
           </serverVariables>          
         </rule>
         <rule name="Reverse Proxy for desktop/10.0/isonline" stopProcessing="true">
-          <match url="^desktop/1[012]\.0/isonline(.*)" />
+          <match url="^desktop/[1-9][0-9]\.[0-9]/isonline(.*)" />
           <action type="Rewrite" url="https://secure.tavultesoft.com/prog/90/isonline{R:1}" />
           <serverVariables>
             <set name="HTTP_X_UNPROXIED_URL" value="https://secure.tavultesoft.com/prog/90/isonline{R:1}" />


### PR DESCRIPTION
Fixes keymanapp/keyman.com#53.

This PR makes 13.0 and future version endpoints work transparently, so we don't need to update them for each release.