### PR TITLE
fix: ignore deprecated keyboards in legacy APIs

### DIFF
--- a/tools/db/build/build_keyboards_script.php
+++ b/tools/db/build/build_keyboards_script.php
@@ -1,15 +1,15 @@
-<?php  
+<?php
   require_once('common.php');
-  
+
   class build_keyboards_sql {
-    
+
     private $keyboards_path, $cache_path;
-    
-    function execute($data_root, $do_force) {    
+
+    function execute($data_root, $do_force) {
       $this->keyboards_path = $data_root . '/keyboard_info/';
       $this->cache_path = $data_root;
       $this->force = $do_force;
-      
+
       if(!is_dir($this->cache_path)) {
         mkdir($this->cache_path, 0777, true) || fail("Unable to create folder " . $this->cache_path);
       }
@@ -23,13 +23,13 @@
       }
 
       cache(URI_KEYBOARD_INFO_ZIP, $this->cache_path . 'keyboard_info.zip', 60 * 60 * 24 * 7, $this->force) || fail("Unable to download keyboard_info.zip");
-      
+
       $this->unzip() || fail("Unable to extract keyboard_info.zip");
-      
-      if(($v = $this->build()) === false) 
+
+      if(($v = $this->build()) === false)
         fail("Unable to build keyboards.sql");
       file_put_contents($this->cache_path . "keyboards.sql", $v) || fail("Unable to write keyboards.sql to " . $this->cache_path);
-      
+
       return true;
     }
 
@@ -39,15 +39,15 @@
 
     private $keyboards = array();
     private $link;
-    
+
     function unzip() {
       $zip = new ZipArchive();
-      if(!$zip->open($this->cache_path . 'keyboard_info.zip', 0)) 
+      if(!$zip->open($this->cache_path . 'keyboard_info.zip', 0))
         return false;
-      
+
       $result = $zip->extractTo($this->keyboards_path);
       $result |= $zip->close();
-      
+
       return $result;
     }
 
@@ -61,30 +61,30 @@
       if(empty($this->keyboards_path)) {
         return false;
       }
-      
+
       $files = glob($this->keyboards_path . '*.keyboard_info');
       foreach($files as $file) {
         if(!$this->process_file($file)) {
           return false;
         }
       }
-      
-      return 
+
+      return
         $this->generate_keyboard_inserts() .
         $this->generate_keyboard_language_inserts() .
         $this->generate_keyboard_link_inserts() .
         $this->generate_keyboard_related_inserts();
     }
-    
+
     /**
-      Loads a .keyboard_info file, parses it into the 
+      Loads a .keyboard_info file, parses it into the
       keyboards array
     */
     function process_file($file) {
       if(($data = file_get_contents($file)) === false) {
         return false;
       }
-      
+
       $keyboard = json_decode($data);
 
       /* Transform all BCP47 to lower case */
@@ -98,31 +98,31 @@
       }
       $json = json_encode($keyboard, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
       $keyboard->json = $json;
-      
-      array_push($this->keyboards, $keyboard);     
+
+      array_push($this->keyboards, $keyboard);
       return true;
     }
-    
+
     /**
       Generate an SQL script to insert entries in to the t_keyboard table
     */
     function generate_keyboard_inserts() {
       $result = <<<END
         INSERT t_keyboard (
-          keyboard_id, 
-          name, 
-          author_name, 
-          author_email, 
-          description, 
-          license, 
-          last_modified, 
+          keyboard_id,
+          name,
+          author_name,
+          author_email,
+          description,
+          license,
+          last_modified,
           version,
 
           min_keyman_version,
           min_keyman_version_1,
           min_keyman_version_2,
           legacy_id,
-          
+
           package_filename,
           package_filesize,
           js_filename,
@@ -133,18 +133,21 @@
           is_rtl,
           is_unicode,
           is_ansi,
-          
+
           includes_welcome,
           includes_documentation,
           includes_fonts,
           includes_visual_keyboard,
-          
+
           platform_windows,
           platform_macos,
           platform_ios,
           platform_android,
           platform_web,
-          
+          platform_linux,
+
+          deprecated,
+
           keyboard_info
         ) VALUES
 END;
@@ -154,7 +157,7 @@ END;
         $isUnicode = isset($keyboard->encodings) && in_array('unicode', $keyboard->encodings);
         $isANSI = isset($keyboard->encodings) && in_array('ansi', $keyboard->encodings);
         $isRTL = isset($keyboard->isRTL) && $keyboard->isRTL;
-        
+
         if(isset($keyboard->minKeymanVersion) && preg_match('/^(\d+)\.(\d+)/', $keyboard->minKeymanVersion, $matches)) {
           $minKeymanVersion1 = $matches[1];
           $minKeymanVersion2 = $matches[2];
@@ -167,12 +170,13 @@ END;
         $includesDocumentation = isset($keyboard->packageIncludes) && in_array('documentation', $keyboard->packageIncludes);
         $includesFonts = isset($keyboard->packageIncludes) && in_array('fonts', $keyboard->packageIncludes);
         $includesVisualKeyboard = isset($keyboard->packageIncludes) && in_array('visualKeyboard', $keyboard->packageIncludes);
-        
+
         $platform_windows = isset($keyboard->platformSupport->windows) && $keyboard->platformSupport->windows != 'none';
         $platform_macos = isset($keyboard->platformSupport->macos) && $keyboard->platformSupport->macos != 'none';
         $platform_ios = isset($keyboard->platformSupport->ios) && $keyboard->platformSupport->ios != 'none';
         $platform_android = isset($keyboard->platformSupport->android) && $keyboard->platformSupport->android != 'none';
         $platform_web = isset($keyboard->platformSupport->desktopWeb) && $keyboard->platformSupport->desktopWeb != 'none'; // todo split into desktopWeb mobileWeb
+        $platform_linux = isset($keyboard->platformSupport->linux) && $keyboard->platformSupport->linux != 'none';
 
         $result .= <<<END
 $comma
@@ -184,12 +188,12 @@ $comma
           {$this->sqlv($keyboard, 'license')},
           {$this->sqld($keyboard, 'lastModifiedDate')},
           {$this->sqlv($keyboard, 'version')},
-          
+
           {$this->sqlv($keyboard, 'minKeymanVersion')},
           $minKeymanVersion1,
           $minKeymanVersion2,
           {$this->sqli($keyboard, 'legacyId')},
-    
+
           {$this->sqlv($keyboard, 'packageFilename')},
           {$this->sqli($keyboard, 'packageFileSize')},
           {$this->sqlv($keyboard, 'jsFilename')},
@@ -200,17 +204,20 @@ $comma
           {$this->sqlb($isRTL)},
           {$this->sqlb($isUnicode)},
           {$this->sqlb($isANSI)},
-    
+
           {$this->sqlb($includesWelcome)},
           {$this->sqlb($includesDocumentation)},
           {$this->sqlb($includesFonts)},
           {$this->sqlb($includesVisualKeyboard)},
-    
+
           {$this->sqlb($platform_windows)},
           {$this->sqlb($platform_macos)},
           {$this->sqlb($platform_ios)},
           {$this->sqlb($platform_android)},
           {$this->sqlb($platform_web)},
+          {$this->sqlb($platform_linux)},
+
+          0,
 
           {$this->sqlv($keyboard, 'json')})
 END;
@@ -220,15 +227,15 @@ END;
       if($comma == '') return ''; // no entries found
       return $result . ";\n";
     }
-    
+
     /**
       Generate an SQL script to insert entries in to the t_keyboard_language table
     */
     function generate_keyboard_language_inserts() {
       $result = <<<END
         INSERT t_keyboard_language (
-          keyboard_id, 
-          bcp47, 
+          keyboard_id,
+          bcp47,
           language_id,
           region_id,
           script_id
@@ -255,7 +262,7 @@ END;
           $comma = ',';
         }
       }
-      
+
       if($comma == '') return ''; // no entries found
       return $result . ";\n";
     }
@@ -266,8 +273,8 @@ END;
     function generate_keyboard_link_inserts() {
       $result = <<<END
         INSERT t_keyboard_link (
-          keyboard_id, 
-          url, 
+          keyboard_id,
+          url,
           name
         ) VALUES
 END;
@@ -285,7 +292,7 @@ END;
           $comma = ',';
         }
       }
-      
+
       if($comma == '') return ''; // no entries found
       return $result . ";\n";
     }
@@ -296,8 +303,8 @@ END;
     function generate_keyboard_related_inserts() {
       $result = <<<END
         INSERT t_keyboard_related (
-          keyboard_id, 
-          related_keyboard_id, 
+          keyboard_id,
+          related_keyboard_id,
           deprecates
         ) VALUES
 END;
@@ -317,32 +324,32 @@ END;
           $comma = ',';
         }
       }
-      
+
       if($comma == '') return ''; // no entries found
       return $result . ";\n";
     }
-    
+
     /**
       Safe-quotes a SQL string
     */
     function sqlv($o, $s) {
       if($o !== null) {
-        if(isset($o->$s)) $s = $o->$s; 
+        if(isset($o->$s)) $s = $o->$s;
         else return 'null';
       }
       if($s === null) return 'null';
-      
+
       $v = strpos($s, "\0");
       if($v !== FALSE) {
         $s = substr($s, 0, strpos($s, "\0"));
       }
       $s = iconv("UTF-8", "UTF-8//IGNORE", $s); // Strip invalid UTF-8 characters
       //return "'" . mysql_real_escape_string($s) . "'";
-      return 
-        "'" . 
-        str_replace(["'",   "\"",   "\r",  "\n",  "\b",  "\t"], 
-                    ["\\'", "\\\"", "\\r", "\\n", "\\b", "\\t"],  
-                    str_replace("\\", "\\\\", $s) ) . 
+      return
+        "'" .
+        str_replace(["'",   "\"",   "\r",  "\n",  "\b",  "\t"],
+                    ["\\'", "\\\"", "\\r", "\\n", "\\b", "\\t"],
+                    str_replace("\\", "\\\\", $s) ) .
         "'";
     }
 
@@ -350,36 +357,36 @@ END;
       Safe-quotes a SQL date
     */
     function sqld($o, $s) {
-      if(isset($o->$s)) $s = $o->$s; 
+      if(isset($o->$s)) $s = $o->$s;
       else return 'null';
       if($s === null) return 'null';
       $s = substr($s, 0, 19);
       return $this->sqlv(null, $s);
     }
-    
+
     function sqli($o, $s) {
-      if(isset($o->$s)) $s = $o->$s; 
+      if(isset($o->$s)) $s = $o->$s;
       else return 'null';
-      
+
       if(!is_numeric($s)) die('Expecting numeric $s');
       return $s;
     }
-    
+
     function sqlb($b) {
       return $b ? '1' : '0';
     }
-    
+
     function parse_bcp47($bcp47, &$lang, &$region, &$script) {
       $lang = null;
       $region = null;
       $script = null;
-      
+
       // RegEx from https://stackoverflow.com/questions/7035825/regular-expression-for-a-language-tag-as-defined-by-bcp47, https://stackoverflow.com/a/34775980/1836776
       $re = preg_match("/^(?<grandfathered>(?:en-GB-oed|i-(?:ami|bnn|default|enochian|hak|klingon|lux|mingo|navajo|pwn|t(?:a[oy]|su))|sgn-(?:BE-(?:FR|NL)|CH-DE))|(?:art-lojban|cel-gaulish|no-(?:bok|nyn)|zh-(?:guoyu|hakka|min(?:-nan)?|xiang)))|(?:(?<language>(?:[A-Za-z]{2,3}(?:-(?<extlang>[A-Za-z]{3}(?:-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(?:-(?<script>[A-Za-z]{4}))?(?:-(?<region>[A-Za-z]{2}|[0-9]{3}))?(?:-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(?:-(?<extension>[0-9A-WY-Za-wy-z](?:-[A-Za-z0-9]{2,8})+))*)(?:-(?<privateUse>x(?:-[A-Za-z0-9]{1,8})+))?$/Di", $bcp47, $matches);
       if($re === FALSE) {
         return false;
       }
-      
+
       if(isset($matches['language'])) $lang = strtolower($matches['language']);
       if(isset($matches['region'])) $region = strtolower($matches['region']);
       if(isset($matches['script'])) $script = strtolower($matches['script']);

--- a/tools/db/build/legacy-queries.sql
+++ b/tools/db/build/legacy-queries.sql
@@ -26,6 +26,7 @@ BEGIN
   FROM
     t_keyboard k
   WHERE
+    k.deprecated = 0 AND
     k.js_filename IS NOT NULL AND
     (
       k.min_keyman_version_1 < minKeymanVersion1 OR
@@ -47,7 +48,7 @@ BEGIN
     kl.bcp47,
     elc.CountryID region_id, -- maps to t_region
     ec.Area legacy_region,   -- roughly, continent name, mapped in the php layer to a legacy numeric identifier
-    COALESCE(elc.Name, li.Ref_Name, kl.bcp47) name  -- this name is inverted, e.g. "Arabic, Standard", not "Standard Arabic". 
+    COALESCE(elc.Name, li.Ref_Name, kl.bcp47) name  -- this name is inverted, e.g. "Arabic, Standard", not "Standard Arabic".
       -- Some names are missing from Ethnologue, e.g. Ancient and macrolanguages, for those we have no region and
       -- so we will end up with 'world'
   FROM
@@ -75,18 +76,20 @@ BEGIN
     kl.bcp47,
     elc.CountryID region_id, -- maps to t_region
     ec.Area legacy_region,   -- roughly, continent name, mapped in the php layer to a legacy numeric identifier
-    COALESCE(elc.Name, li.Ref_Name, kl.bcp47) name  -- this name is inverted, e.g. "Arabic, Standard", not "Standard Arabic". 
+    COALESCE(elc.Name, li.Ref_Name, kl.bcp47) name  -- this name is inverted, e.g. "Arabic, Standard", not "Standard Arabic".
       -- Some names are missing from Ethnologue, e.g. Ancient and macrolanguages, for those we have no region and
       -- so we will end up with 'world'
   FROM
-    t_keyboard_language kl LEFT JOIN
+    t_keyboard_language kl INNER JOIN
+    t_keyboard k ON kl.keyboard_id = k.keyboard_id LEFT JOIN
     -- This join is imperfect because we are ignoring the region part of the bcp47 tag, for now. We should join across that
     -- and then prioritise that region.
     t_iso639_3 li ON li.CanonicalId = kl.language_id LEFT JOIN -- Join across normalised language id
     t_ethnologue_language_codes elc ON li.Id = elc.LangID LEFT JOIN
     t_ethnologue_country_codes ec ON elc.CountryID = ec.CountryID
   WHERE
-    kl.keyboard_id = keyboard_id OR keyboard_id IS NULL
+    (kl.keyboard_id = keyboard_id OR keyboard_id IS NULL) AND
+    k.deprecated = 0
   ORDER BY
     kl.keyboard_id,
     COALESCE(elc.Name, li.Ref_Name, kl.bcp47);
@@ -104,7 +107,7 @@ BEGIN
     kl.bcp47,
     elc.CountryID region_id, -- maps to t_region
     ec.Area legacy_region,   -- roughly, continent name, mapped in the php layer to a legacy numeric identifier
-    COALESCE(elc.Name, li.Ref_Name, kl.bcp47) name  -- this name is inverted, e.g. "Arabic, Standard", not "Standard Arabic". 
+    COALESCE(elc.Name, li.Ref_Name, kl.bcp47) name  -- this name is inverted, e.g. "Arabic, Standard", not "Standard Arabic".
       -- Some names are missing from Ethnologue, e.g. Ancient and macrolanguages, for those we have no region and
       -- so we will end up with 'world'
   FROM
@@ -121,6 +124,7 @@ BEGIN
       FROM
         t_keyboard k
       WHERE
+        k.deprecated = 0 AND
         k.js_filename IS NOT NULL AND
         EXISTS(SELECT * FROM t_keyboard_language kl WHERE kl.keyboard_id = k.keyboard_id AND kl.bcp47 = bcp47)
     )
@@ -157,6 +161,7 @@ BEGIN
   FROM
     t_keyboard k
   WHERE
+    k.deprecated = 0 AND
     k.js_filename IS NOT NULL AND
     (
       k.min_keyman_version_1 < minKeymanVersion1 OR
@@ -215,6 +220,7 @@ BEGIN
     t_region r ON kl.region_id = r.region_id LEFT JOIN
     t_script s ON kl.script_id = s.script_id
   WHERE
+    k.deprecated = 0 AND
     (kl.bcp47 = bcp47 OR bcp47 IS NULL) AND
     (
       k.min_keyman_version_1 < minKeymanVersion1 OR
@@ -261,6 +267,7 @@ BEGIN
     t_region r ON kl.region_id = r.region_id LEFT JOIN
     t_script s ON kl.script_id = s.script_id
   WHERE
+    k.deprecated = 0 AND
     (kl.bcp47 = bcp47 OR bcp47 IS NULL) AND
     (
       k.min_keyman_version_1 < minKeymanVersion1 OR
@@ -299,9 +306,10 @@ BEGIN
   FROM
     t_keyboard k
   WHERE
+    k.deprecated = 0 AND
     k.keyboard_id IN (
       SELECT
-        kl.keyboard_id 
+        kl.keyboard_id
       FROM
         t_keyboard_language kl
       WHERE


### PR DESCRIPTION
Fixes #38.

Deprecated keyboards are no longer included in search results when using
the legacy APIs. This reduces the result set for Android, iOS and
KeymanWeb pickers.

Also, adds Linux platform data to the keyboard metadata.