### PR TITLE
feat: initial test case for /keyboard

### DIFF
--- a/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json
+++ b/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json
@@ -61,7 +61,9 @@
         "oskFont": { "$ref": "#/definitions/KeyboardFontInfo" },
         "example": { "$ref": "#/definitions/KeyboardExampleInfo" },
         "displayName": { "type": "string" },
-        "languageName": { "type": "string" }
+        "languageName": { "type": "string" },
+        "scriptName": { "type": "string" },
+        "regionName": { "type": "string" }
       },
       "required": [],
       "additionalProperties": false

--- a/script/keyboard/keyboard.inc.php
+++ b/script/keyboard/keyboard.inc.php
@@ -1,0 +1,34 @@
+<?php
+  namespace Keyman\Site\com\keyman\api;
+
+  require_once(__DIR__ . '/../../tools/util.php');
+
+  class Keyboard {
+    static function execute($mssql, $id) {
+
+      $stmt = $mssql->prepare('SELECT keyboard_info FROM t_keyboard WHERE keyboard_id = :keyboard_id');
+      $stmt->bindParam(":keyboard_id", $id);
+      $stmt->execute();
+      $data = $stmt->fetchAll();
+      if(count($data) == 0) {
+        return NULL;
+      }
+      $json = json_decode($data[0][0]);
+
+      // Add the related keyboards that are deprecated
+
+      $stmt = $mssql->prepare('SELECT keyboard_id FROM t_keyboard_related WHERE related_keyboard_id = :related_keyboard_id AND deprecates <> 0');
+      $stmt->bindParam(":related_keyboard_id", $id);
+      $stmt->execute();
+      $data = $stmt->fetchAll();
+      for($i = 0; $i < count($data); $i++) {
+        if(!isset($json->related)) {
+          $json->related = new \stdClass();
+        }
+        $name = $data[$i][0];
+        $json->related->$name = array("deprecatedBy" => true);
+      }
+
+      return $json;
+    }
+  }

--- a/script/keyboard/keyboard.php
+++ b/script/keyboard/keyboard.php
@@ -1,11 +1,11 @@
 <?php
-  require_once('../../tools/util.php');
+  require_once(__DIR__ . '/../../tools/util.php');
 
   allow_cors();
   json_response();
 
-  require_once('../../tools/db/db.php');
-
+  require_once(__DIR__ . '/keyboard.inc.php');
+  require_once(__DIR__ . '/../../tools/db/db.php');
   $mssql = Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
 
   header('Link: <https://api.keyman.com/schemas/keyboard_info.distribution.json#>; rel="describedby"');
@@ -26,28 +26,9 @@
    * @param id    the identifier of the keyboard to lookup
    */
 
-  $stmt = $mssql->prepare('SELECT keyboard_info FROM t_keyboard WHERE keyboard_id = :keyboard_id');
-  $stmt->bindParam(":keyboard_id", $id);
-  $stmt->execute();
-  $data = $stmt->fetchAll();
-  if(count($data) == 0) {
-    fail('Keyboard not found');
-  }
-  $json = json_decode($data[0][0]);
-
-  // Add the related keyboards that are deprecated
-
-  $stmt = $mssql->prepare('SELECT keyboard_id FROM t_keyboard_related WHERE related_keyboard_id = :related_keyboard_id AND deprecates <> 0');
-  $stmt->bindParam(":related_keyboard_id", $id);
-  $stmt->execute();
-  $data = $stmt->fetchAll();
-  for($i = 0; $i < count($data); $i++) {
-    if(!isset($json->related)) {
-      $json->related = new stdClass();
-    }
-    $name = $data[$i][0];
-    $json->related->$name = array("deprecatedBy" => true);
+  $json = \Keyman\Site\com\keyman\api\Keyboard::execute($mssql, $id);
+  if($json === NULL) {
+    fail('Keyboard not found', 404);
   }
 
   echo json_encode($json, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);
-?>

--- a/tests/KeyboardTest.php
+++ b/tests/KeyboardTest.php
@@ -3,7 +3,7 @@
 namespace Keyman\Site\com\keyman\api\tests;
 
 require_once(__DIR__ . '/../tools/base.inc.php');
-//require_once(__DIR__ . '/../script/search/search.inc.php');
+require_once(__DIR__ . '/../script/keyboard/keyboard.inc.php');
 require_once(__DIR__ . '/TestUtils.inc.php');
 require_once(__DIR__ . '/TestDBBuild.inc.php');
 
@@ -23,8 +23,8 @@ final class KeyboardTest extends TestCase
     $schema = TestUtils::LoadJSONSchema(KeyboardTest::SchemaFilename);
     $mssql = \Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
 
-    $m = new \Keyman\Site\com\keyman\api\Model();
-    $json = $m->getModelJson($mssql, 'gff.am.gff_amharic');
+    $k = new \Keyman\Site\com\keyman\api\Keyboard();
+    $json = $k->execute($mssql, 'newa_traditional');
     $this->assertNotNull($json);
 
     // This will throw an exception if it does not pass

--- a/tests/KeyboardTest.php
+++ b/tests/KeyboardTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 final class KeyboardTest extends TestCase
 {
-  private const SchemaFilename = "/search/1.0.2/search.json";
+  private const SchemaFilename = "/keyboard_info.distribution/1.0.6/keyboard_info.distribution.json";
 
   static function setUpBeforeClass(): void
   {
@@ -20,8 +20,17 @@ final class KeyboardTest extends TestCase
 
   public function testSimpleResultValidatesAgainstSchema(): void
   {
-    $this->markTestIncomplete(
-      'Finish this'
-    );
+    $schema = TestUtils::LoadJSONSchema(KeyboardTest::SchemaFilename);
+    $mssql = \Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
+
+    $m = new \Keyman\Site\com\keyman\api\Model();
+    $json = $m->getModelJson($mssql, 'gff.am.gff_amharic');
+    $this->assertNotNull($json);
+
+    // This will throw an exception if it does not pass
+    $schema->in($json);
+
+    // Once we get here we know this test has passed so make PHPUnit happy
+    $this->assertTrue(true);
   }
 }


### PR DESCRIPTION
This also reverts a mistake in the keyboard_info schema where certain fields that are in use were deleted (scriptName, regionName, languageName).

See also documentation update at https://github.com/keymanapp/help.keyman.com/pull/185