### PR TITLE
change: package schema now draft-04 compliant

### DIFF
--- a/schemas/package/1.1.0/package.json
+++ b/schemas/package/1.1.0/package.json
@@ -225,8 +225,7 @@
           "$ref": "#/definitions/infoItem"
         }
       },
-      "additionalProperties": false,
-      "required": []
+      "additionalProperties": false
     },
     "infoItem": {
       "type": "object",


### PR DESCRIPTION
One small tweak to our KMP schema's JSON and we can achieve draft-04 compliance, which is quite significant given how many tools out there target this draft but not later ones.