### PR TITLE
feat: groundwork for rest-based test cases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,12 +2,13 @@
     "require": {
         "sentry/sdk": "2.1.0",
         "php-http/curl-client": "^2.1",
-        "swaggest/json-schema": "^0.12.29"
+        "swaggest/json-schema": "^0.12.29",
+        "guzzlehttp/guzzle": "^6.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"
     },
     "scripts": {
-      "test": "vendor\\bin\\phpunit --testdox"
+      "test": "vendor\\bin\\phpunit --color --testdox"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c52a39ce482b14c6d9daaee83a78efef",
+    "content-hash": "b1d875533c01ad3e128f73b0a9643b73",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -3345,5 +3345,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/tests/rest/RestTestCase.php
+++ b/tests/rest/RestTestCase.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Keyman\Site\com\keyman\api\tests\rest;
+
+require_once(__DIR__ . '/../../tools/base.inc.php');
+require_once(__DIR__ . '/../TestUtils.inc.php');
+
+use Keyman\Site\com\keyman\api\tests\TestUtils;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp;
+
+class RestTestCase extends TestCase
+{
+  protected $http;
+
+  public function setUp(): void
+  {
+    $this->http = new GuzzleHttp\Client(['base_uri' => TestUtils::Hostname().'/']);
+  }
+
+  public function tearDown(): void
+  {
+    $this->http = null;
+  }
+
+  protected function assertStandardTextRestResponses($response): void
+  {
+    $this->assertEquals(200, $response->getStatusCode());
+
+    $headers = $response->getHeaders();
+
+    $contentType = $headers["Content-Type"];
+    $this->assertCount(1, $contentType);
+    $this->assertEquals("text/plain; charset=utf-8", $contentType[0]);
+
+    $cors = $headers["Access-Control-Allow-Origin"];
+    $this->assertCount(1, $cors);
+    $this->assertEquals("*", $cors[0]);
+  }
+
+  protected function assertStandardJsonRestResponses($response): void
+  {
+    $this->assertEquals(200, $response->getStatusCode());
+
+    $headers = $response->getHeaders();
+
+    $contentType = $headers["Content-Type"];
+    $this->assertCount(1, $contentType);
+    $this->assertEquals("application/json; charset=utf-8", $contentType[0]);
+
+    $cors = $headers["Access-Control-Allow-Origin"];
+    $this->assertCount(1, $cors);
+    $this->assertEquals("*", $cors[0]);
+  }
+
+  protected function assertJsonSchemaLinkedAndValidated($response, $schema): void
+  {
+    $headers = $response->getHeaders();
+
+    // The caller will pass in a versioned schema filename; we want the unversioned equivalent to check the Link header
+    $base_schema = basename($schema);
+    $links = $headers["Link"];
+    $this->assertCount(1, $links); // we should only have one Link header, the JSON schema
+    $this->assertEquals("<https://api.keyman.com/schemas/$base_schema#>; rel=\"describedby\"" , $links[0]);
+
+    // Now validate against the versioned schema file
+    $schema = TestUtils::LoadJSONSchema($schema);
+
+    $json = $response->getBody();
+    $this->assertNotFalse($json);
+
+    // This will throw an exception if it does not pass
+    $schema->in($json);
+  }
+}

--- a/tests/rest/RestVersionTest.php
+++ b/tests/rest/RestVersionTest.php
@@ -3,29 +3,39 @@
 namespace Keyman\Site\com\keyman\api\tests\rest;
 
 require_once(__DIR__ . '/../../tools/base.inc.php');
-require_once(__DIR__ . '/../TestUtils.inc.php');
+require_once(__DIR__ . '/RestTestCase.php');
 
-use Keyman\Site\com\keyman\api\tests\TestUtils;
-use PHPUnit\Framework\TestCase;
-
-final class RestVersionTest extends TestCase
+final class RestVersionTest extends RestTestCase
 {
   private const SchemaFilename = "/version/2.0/version.json";
 
-  public function testSimpleResultValidatesAgainstSchema(): void
+  public function testBasicRequest(): void
   {
-    $schema = TestUtils::LoadJSONSchema(RestVersionTest::SchemaFilename);
+    // NOTE: this test currently works against live data because we have not mocked the
+    // version api yet. So we cannot test the result against known fixed values; we can
+    // reliably assume there will *always* be a stable windows version, though!
+    $response = $this->http->request('GET', 'version/windows/stable');
+    $this->assertStandardJsonRestResponses($response);
+    $this->assertJsonSchemaLinkedAndValidated($response, RestVersionTest::SchemaFilename);
 
-    $json = file_get_contents(TestUtils::Hostname() ."/version/windows/alpha");
-    $this->assertNotFalse($json);
+    $json = json_decode($response->getBody()->getContents());
 
-    $ver = json_decode($json);
-    $this->assertNotNull($json);
+    // Now check the actual content, as far as we can
+    $this->assertEquals("windows", $json->platform);
+    $this->assertEquals("stable", $json->level);
+    // The version string will be a.b.c or a.b.c.d (in the future we hope to use a.b.c only)
+    $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+(\.\d)?$/', $json->version);
+  }
 
-    // This will throw an exception if it does not pass
-    $schema->in($ver);
+  public function testLegacyRequest(): void
+  {
+    // Corresponds to the last legacy stable web version 2.0.473. This query should always return "473"
+    // as there will never be a newer version with the legacy API.
+    $LEGACY_WEB_STABLE_VERSION = 473;
 
-    // Once we get here we know this test has passed so make PHPUnit happy
-    $this->assertTrue(true);
+    $response = $this->http->request('GET', 'version');
+    $this->assertStandardTextRestResponses($response);
+    $body = $response->getBody()->getContents();
+    $this->assertEquals($body, $LEGACY_WEB_STABLE_VERSION);
   }
 }

--- a/tools/util.php
+++ b/tools/util.php
@@ -37,7 +37,7 @@
 
   function text_response() {
     ini_set('html_errors', 0);
-    header('Content-Type: text/plain');
+    header('Content-Type: text/plain; charset=utf-8');
   }
 
   function json_response() {


### PR DESCRIPTION
This adds the `RestTestCase` class with assertion helpers for JSON schema and standard headers, and adds additional test cases for the version API that use these helpers.