### PR TITLE
fix: adjust langtag search weight

### DIFF
--- a/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json
+++ b/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json
@@ -42,8 +42,7 @@
       },
       "required": [
         "license", "languages"
-      ],
-      "additionalProperties": false
+      ]
     },
 
     "KeyboardLanguageInfo": {

--- a/schemas/search/2.0/search.json
+++ b/schemas/search/2.0/search.json
@@ -23,17 +23,35 @@
         "totalRows": { "type": "number" },
         "totalPages": { "type": "number" }
       },
-      "required": ["range", "text", "pageSize", "pageNumber", "totalRows", "totalPages"]
+      "required": ["range", "text", "pageSize", "pageNumber", "totalRows", "totalPages"],
+      "additionalProperties": false
     },
 
     "SearchKeyboard": {
-      "anyOf": [
+      "allOf": [
         { "$ref": "/keyboard_info.source/1.0.6/keyboard_info.source.json#/definitions/KeyboardInfo" },
         {
-          "type": "object",
           "properties": {
-            "match": { "type": "object" }
-          }
+            "match": {
+              "type": "object",
+              "properties": {
+                "name": { "oneOf": [ { "type": "string" }, { "type": "null"} ] },
+                "type": { "type": "string", "enum": [
+                  "keyboard", "keyboard_id", "description", "legacy_keyboard_id",
+                  "language", "language_bcp47_tag",
+                  "country", "country_iso3166_code",
+                  "script", "script_iso15924_code"
+                ] },
+                "tag": { "type": "string" },
+                "weight": { "type": "number" },
+                "downloads": { "type": "number" },
+                "finalWeight": { "type": "number" }
+              },
+              "required": ["name","type","weight","downloads","finalWeight"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["match"]
         }
       ]
     }

--- a/script/search/2.0/search.inc.php
+++ b/script/search/2.0/search.inc.php
@@ -270,10 +270,14 @@
         $rowdata->match = [
           'name' => $row['match_name'],
           'type' => $row['match_type'],
-          'weight' => $row['match_weight'],
-          'downloads' => $row['download_count'],
-          'final_weight' => $row['final_weight']
+          'weight' => floatval($row['match_weight']),
+          'downloads' => intval($row['download_count']),
+          'finalWeight' => floatval($row['final_weight'])
         ];
+
+        // TODO: when searching for country or script, then we get a fairly 'random' first match
+        //       Is there any way we can improve this?
+        if(!empty($row['match_tag'])) $rowdata->match['tag'] = $row['match_tag'];
 
         array_push($result->keyboards, $rowdata);
       }

--- a/tests/fixtures/Search.2.0.ethiopic.json
+++ b/tests/fixtures/Search.2.0.ethiopic.json
@@ -99,9 +99,10 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
-                "weight": "30",
-                "downloads": "470",
-                "final_weight": "214.64574282049253"
+                "tag": "tig",
+                "weight": 30,
+                "downloads": 470,
+                "finalWeight": 214.64574282049253
             }
         },
         {
@@ -162,9 +163,10 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "234",
-                "final_weight": "193.78756542432478"
+                "tag": "ti-ER",
+                "weight": 30,
+                "downloads": 234,
+                "finalWeight": 193.78756542432478
             }
         },
         {
@@ -228,9 +230,10 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "226",
-                "final_weight": "192.74850052444208"
+                "tag": "ti",
+                "weight": 30,
+                "downloads": 226,
+                "finalWeight": 192.74850052444208
             }
         },
         {
@@ -325,9 +328,10 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
-                "weight": "30",
-                "downloads": "149",
-                "final_weight": "180.31905882288765"
+                "tag": "tig",
+                "weight": 30,
+                "downloads": 149,
+                "finalWeight": 180.31905882288765
             }
         },
         {
@@ -375,9 +379,10 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "tag": "ti",
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -425,9 +430,10 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "tag": "ti",
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -508,9 +514,10 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "tag": "ti",
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -556,9 +563,10 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "tag": "ti",
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -604,9 +612,10 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "tag": "ti",
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -646,9 +655,10 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "tag": "ti",
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         }
    ]

--- a/tests/fixtures/Search.2.0.khmer-angkor.json
+++ b/tests/fixtures/Search.2.0.khmer-angkor.json
@@ -62,9 +62,9 @@
             "match": {
                 "name": "Khmer Angkor",
                 "type": "keyboard",
-                "weight": "90",
-                "downloads": "37",
-                "final_weight": "417.3827543753747"
+                "weight": 90,
+                "downloads": 37,
+                "finalWeight": 417.3827543753747
             }
         }
     ]

--- a/tests/fixtures/Search.2.0.khmer-keyboards.json
+++ b/tests/fixtures/Search.2.0.khmer-keyboards.json
@@ -62,9 +62,9 @@
             "match": {
                 "name": "Khmer Angkor",
                 "type": "keyboard",
-                "weight": "60",
-                "downloads": "37",
-                "final_weight": "278.25516958358315"
+                "weight": 60,
+                "downloads": 37,
+                "finalWeight": 278.25516958358315
             }
         },
         {
@@ -108,9 +108,9 @@
             "match": {
                 "name": "Khmer (NIDA) Basic",
                 "type": "keyboard",
-                "weight": "35",
-                "downloads": "21",
-                "final_weight": "143.18648586754105"
+                "weight": 35,
+                "downloads": 21,
+                "finalWeight": 143.18648586754105
             }
         },
         {
@@ -193,9 +193,9 @@
             "match": {
                 "name": "Khmer (SIL)",
                 "type": "keyboard",
-                "weight": "35",
-                "downloads": "3",
-                "final_weight": "83.520302639196174"
+                "weight": 35,
+                "downloads": 3,
+                "finalWeight": 83.520302639196174
             }
         },
         {
@@ -241,9 +241,9 @@
             "match": {
                 "name": "Khmer Basic",
                 "type": "keyboard",
-                "weight": "35",
-                "downloads": "1",
-                "final_weight": "59.260151319598087"
+                "weight": 35,
+                "downloads": 1,
+                "finalWeight": 59.260151319598087
             }
         },
         {
@@ -288,9 +288,9 @@
             "match": {
                 "name": null,
                 "type": "description",
-                "weight": "5",
-                "downloads": "1",
-                "final_weight": "8.465735902799727"
+                "weight": 5,
+                "downloads": 1,
+                "finalWeight": 8.465735902799727
             }
         },
         {
@@ -336,9 +336,9 @@
             "match": {
                 "name": "NiDA Khmer",
                 "type": "keyboard",
-                "weight": "60",
-                "downloads": "0",
-                "final_weight": "60.0"
+                "weight": 60,
+                "downloads": 0,
+                "finalWeight": 60.0
             }
         },
         {
@@ -378,9 +378,9 @@
             "match": {
                 "name": "Khmer Basic",
                 "type": "keyboard",
-                "weight": "35",
-                "downloads": "0",
-                "final_weight": "35.0"
+                "weight": 35,
+                "downloads": 0,
+                "finalWeight": 35.0
             }
         }
     ]

--- a/tests/fixtures/Search.2.0.khmer.json
+++ b/tests/fixtures/Search.2.0.khmer.json
@@ -54,9 +54,10 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "210",
-                "downloads": "37",
-                "final_weight": "973.89309354254101"
+                "tag": "km",
+                "weight": 210,
+                "downloads": 37,
+                "finalWeight": 973.89309354254101
             }
         },
         {
@@ -139,9 +140,10 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "356",
-                "downloads": "3",
-                "final_weight": "849.52079255868114"
+                "tag": "km",
+                "weight": 356,
+                "downloads": 3,
+                "finalWeight": 849.52079255868114
             }
         },
         {
@@ -185,9 +187,10 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "185",
-                "downloads": "21",
-                "final_weight": "756.84285387128853"
+                "tag": "km",
+                "weight": 185,
+                "downloads": 21,
+                "finalWeight": 756.84285387128853
             }
         },
         {
@@ -233,9 +236,10 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "185",
-                "downloads": "1",
-                "final_weight": "313.23222840358989"
+                "tag": "km",
+                "weight": 185,
+                "downloads": 1,
+                "finalWeight": 313.23222840358989
             }
         },
         {
@@ -280,9 +284,9 @@
             "match": {
                 "name": null,
                 "type": "description",
-                "weight": "10",
-                "downloads": "1",
-                "final_weight": "16.931471805599454"
+                "weight": 10,
+                "downloads": 1,
+                "finalWeight": 16.931471805599454
             }
         },
         {
@@ -328,9 +332,10 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "210",
-                "downloads": "0",
-                "final_weight": "210.0"
+                "tag": "km",
+                "weight": 210,
+                "downloads": 0,
+                "finalWeight": 210.0
             }
         },
         {
@@ -370,9 +375,10 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "185",
-                "downloads": "0",
-                "final_weight": "185.0"
+                "tag": "km",
+                "weight": 185,
+                "downloads": 0,
+                "finalWeight": 185.0
             }
         }
     ],

--- a/tests/fixtures/Search.2.0.khmer.json
+++ b/tests/fixtures/Search.2.0.khmer.json
@@ -1,387 +1,387 @@
 {
-  "context": {
-      "range": "Keyboards matching 'khmer'",
-      "text": "khmer",
-      "pageSize": 10,
-      "pageNumber": 1,
-      "totalRows": 7,
-      "totalPages": 1
-  },
-  "keyboards": [
-      {
-          "license": "mit",
-          "languages": {
-              "km": {
-                  "font": {
-                      "family": "Mondulkiri",
-                      "source": [
-                          "Mondulkiri-R.ttf"
-                      ]
-                  },
-                  "displayName": "Central Khmer",
-                  "languageName": "Central Khmer"
-              }
-          },
-          "description": "<p>Khmer Unicode keyboard layout based on the NiDA keyboard layout. Automatically corrects many common keying errors.</p>",
-          "related": {
-              "khmer10": {
-                  "deprecates": true
-              }
-          },
-          "id": "khmer_angkor",
-          "name": "Khmer Angkor",
-          "authorName": "Makara Sok",
-          "authorEmail": "makara@keyman.com",
-          "lastModifiedDate": "2020-06-12T00:39:43.475Z",
-          "sourcePath": "release/k/khmer_angkor",
-          "version": "1.0.6",
-          "packageFilename": "khmer_angkor.kmp",
-          "jsFilename": "khmer_angkor.js",
-          "encodings": [
-              "unicode"
-          ],
-          "jsFileSize": 63881,
-          "packageFileSize": 2639344,
-          "packageIncludes": [
-              "visualKeyboard",
-              "welcome",
-              "fonts",
-              "documentation"
-          ],
-          "minKeymanVersion": "10.0",
-          "helpLink": "https://help.keyman.com/keyboard/khmer_angkor",
-          "platformSupport": {
-              "windows": "full",
-              "macos": "full",
-              "linux": "full",
-              "android": "full",
-              "ios": "full",
-              "desktopWeb": "full",
-              "mobileWeb": "full"
-          },
-          "match": {
-              "name": "Khmer",
-              "type": "language",
-              "weight": "185",
-              "downloads": "37",
-              "final_weight": "857.9534395493813"
-          }
-      },
-      {
-          "license": "mit",
-          "description": "Khmer (NIDA) Basic generated from template",
-          "id": "basic_kbdkni",
-          "languages": {
-              "km": {
-                  "displayName": "Central Khmer",
-                  "languageName": "Central Khmer"
-              }
-          },
-          "name": "Khmer (NIDA) Basic",
-          "lastModifiedDate": "2020-06-12T00:36:29.888Z",
-          "sourcePath": "release/basic/basic_kbdkni",
-          "version": "1.0",
-          "packageFilename": "basic_kbdkni.kmp",
-          "jsFilename": "basic_kbdkni.js",
-          "encodings": [
-              "unicode"
-          ],
-          "jsFileSize": 17913,
-          "packageFileSize": 401287,
-          "packageIncludes": [
-              "visualKeyboard",
-              "documentation",
-              "welcome",
-              "fonts"
-          ],
-          "minKeymanVersion": "10.0",
-          "helpLink": "https://help.keyman.com/keyboard/basic_kbdkni",
-          "platformSupport": {
-              "windows": "full",
-              "macos": "full",
-              "linux": "full",
-              "android": "full",
-              "ios": "full",
-              "desktopWeb": "full",
-              "mobileWeb": "full"
-          },
-          "match": {
-              "name": "Khmer",
-              "type": "language",
-              "weight": "160",
-              "downloads": "21",
-              "final_weight": "654.56679253733057"
-          }
-      },
-      {
-          "license": "mit",
-          "description": "This keyboard is designed for any languages using the Khmer script. This keyboard is very similar to the Khmer ABS keyboard, but it is a Unicode keyboard.",
-          "id": "sil_khmer",
-          "languages": {
-              "km": {
-                  "displayName": "Central Khmer",
-                  "languageName": "Central Khmer"
-              },
-              "brb-khmr": {
-                  "displayName": "Lave (Khmer)",
-                  "languageName": "Lave",
-                  "scriptName": "Khmer"
-              },
-              "cmo-khmr": {
-                  "displayName": "Central Mnong (Khmer)",
-                  "languageName": "Central Mnong",
-                  "scriptName": "Khmer"
-              },
-              "jra-khmr": {
-                  "displayName": "Jarai (Khmer)",
-                  "languageName": "Jarai",
-                  "scriptName": "Khmer"
-              },
-              "kdt-khmr": {
-                  "displayName": "Kuy (Khmer)",
-                  "languageName": "Kuy",
-                  "scriptName": "Khmer"
-              },
-              "krr-khmr": {
-                  "displayName": "Krung (Khmer)",
-                  "languageName": "Krung",
-                  "scriptName": "Khmer"
-              },
-              "krv-khmr": {
-                  "displayName": "Kavet (Khmer)",
-                  "languageName": "Kavet",
-                  "scriptName": "Khmer"
-              },
-              "kxm-khmr": {
-                  "displayName": "Northern Khmer (Khmer)",
-                  "languageName": "Northern Khmer",
-                  "scriptName": "Khmer"
-              },
-              "tpu-khmr": {
-                  "displayName": "Tampuan (Khmer)",
-                  "languageName": "Tampuan",
-                  "scriptName": "Khmer"
-              }
-          },
-          "name": "Khmer (SIL)",
-          "lastModifiedDate": "2020-06-12T00:41:17.251Z",
-          "sourcePath": "release/sil/sil_khmer",
-          "version": "1.5",
-          "packageFilename": "sil_khmer.kmp",
-          "jsFilename": "sil_khmer.js",
-          "encodings": [
-              "unicode"
-          ],
-          "jsFileSize": 20855,
-          "packageFileSize": 98179,
-          "packageIncludes": [
-              "documentation",
-              "visualKeyboard",
-              "welcome"
-          ],
-          "minKeymanVersion": "10.0",
-          "helpLink": "https://help.keyman.com/keyboard/sil_khmer",
-          "platformSupport": {
-              "windows": "full",
-              "macos": "full",
-              "linux": "full",
-              "android": "full",
-              "ios": "full",
-              "desktopWeb": "full",
-              "mobileWeb": "full"
-          },
-          "match": {
-              "name": "Khmer",
-              "type": "language",
-              "weight": "270",
-              "downloads": "3",
-              "final_weight": "644.29947750237056"
-          }
-      },
-      {
-          "license": "mit",
-          "description": "This keyboard layout is designed for Khmer.  It includes an on screen keyboard which can be viewed by clicking on the Keyman icon and selecting the On Screen Keyboard menu item. The keyboard layout follows the Windows 10 Khmer layout.",
-          "related": {
-              "kbdkhmr": {
-                  "deprecates": true
-              }
-          },
-          "id": "basic_kbdkhmr",
-          "languages": {
-              "km": {
-                  "displayName": "Central Khmer",
-                  "languageName": "Central Khmer"
-              }
-          },
-          "name": "Khmer Basic",
-          "lastModifiedDate": "2020-06-12T00:36:29.171Z",
-          "sourcePath": "release/basic/basic_kbdkhmr",
-          "version": "1.1",
-          "packageFilename": "basic_kbdkhmr.kmp",
-          "jsFilename": "basic_kbdkhmr.js",
-          "encodings": [
-              "unicode"
-          ],
-          "jsFileSize": 16286,
-          "packageFileSize": 70886,
-          "packageIncludes": [
-              "visualKeyboard",
-              "documentation",
-              "welcome"
-          ],
-          "minKeymanVersion": "10.0",
-          "helpLink": "https://help.keyman.com/keyboard/basic_kbdkhmr",
-          "platformSupport": {
-              "windows": "full",
-              "macos": "full",
-              "linux": "full",
-              "desktopWeb": "full",
-              "mobileWeb": "full"
-          },
-          "match": {
-              "name": "Khmer",
-              "type": "language",
-              "weight": "160",
-              "downloads": "1",
-              "final_weight": "270.90354888959126"
-          }
-      },
-      {
-          "license": "mit",
-          "description": "Krung is a language spoken in the northern part of Cambodia. Khmer script was adopted and used for this language. This Keyman keyboard was developed based on an existing tool (Clever Rabit) which used the Romanized version of Krung. However, a few customizations have been made to make this keyboard perform as expected. See the documentation on the romanization and examples in our welcome page.",
-          "id": "krung",
-          "languages": {
-              "krr-khmr": {
-                  "displayName": "Krung (Khmer)",
-                  "languageName": "Krung",
-                  "scriptName": "Khmer"
-              }
-          },
-          "name": "Krung",
-          "lastModifiedDate": "2020-06-12T00:39:45.105Z",
-          "sourcePath": "release/k/krung",
-          "version": "1.0.1",
-          "packageFilename": "krung.kmp",
-          "jsFilename": "krung.js",
-          "encodings": [
-              "unicode"
-          ],
-          "jsFileSize": 117392,
-          "packageFileSize": 1324624,
-          "packageIncludes": [
-              "visualKeyboard",
-              "documentation",
-              "welcome",
-              "fonts"
-          ],
-          "minKeymanVersion": "10.0",
-          "helpLink": "https://help.keyman.com/keyboard/krung",
-          "platformSupport": {
-              "windows": "full",
-              "macos": "full",
-              "linux": "full",
-              "android": "full",
-              "ios": "full",
-              "desktopWeb": "full",
-              "mobileWeb": "full"
-          },
-          "match": {
-              "name": null,
-              "type": "description",
-              "weight": "10",
-              "downloads": "1",
-              "final_weight": "16.931471805599454"
-          }
-      },
-      {
-          "id": "khmer10",
-          "name": "NiDA Khmer",
-          "description": "Khmer Unicode keyboard layout using the NiDA keyboard layout.",
-          "authorName": "Andrew Cunningham",
-          "license": "freeware",
-          "lastModifiedDate": "2007-02-08T13:43:29Z",
-          "links": [],
-          "packageFilename": "khmer10.kmp",
-          "encodings": [
-              "unicode"
-          ],
-          "packageIncludes": [
-              "fonts",
-              "visualKeyboard"
-          ],
-          "version": "1.0",
-          "minKeymanVersion": "5.0",
-          "platformSupport": {
-              "windows": "full",
-              "desktopWeb": "full",
-              "ios": "basic",
-              "android": "basic",
-              "macos": "full"
-          },
-          "legacyId": 401,
-          "jsFilename": "khmer10.js",
-          "documentationFilename": "khmer10.html",
-          "languages": {
-              "km": {
-                  "displayName": "Central Khmer",
-                  "languageName": "Central Khmer"
-              }
-          },
-          "sourcePath": "legacy/k/khmer10",
-          "jsFileSize": 11824,
-          "packageFileSize": 110008,
-          "documentationFileSize": 22745,
-          "helpLink": "https://help.keyman.com/keyboard/khmer10",
-          "deprecated": true,
-          "match": {
-              "name": "Khmer",
-              "type": "language",
-              "weight": "185",
-              "downloads": "0",
-              "final_weight": "185.0"
-          }
-      },
-      {
-          "id": "kbdkhmr",
-          "name": "Khmer Basic",
-          "description": "This keyboard layout is designed for Khmer.  It includes an on screen keyboard which can be viewed by clicking on the Keyman icon and selecting the On Screen Keyboard menu item. The package also includes the Khmer font <b>Khmer OS</b>. The keyboard layout follows the Windows Vista Khmer layout.",
-          "authorName": "Tavultesoft",
-          "license": "freeware",
-          "lastModifiedDate": "2013-02-18T11:24:02Z",
-          "links": [],
-          "packageFilename": "kbdkhmr.kmp",
-          "encodings": [
-              "unicode"
-          ],
-          "packageIncludes": [
-              "fonts",
-              "visualKeyboard",
-              "welcome"
-          ],
-          "version": "1.0.1",
-          "minKeymanVersion": "7.0",
-          "platformSupport": {
-              "windows": "full",
-              "macos": "full"
-          },
-          "legacyId": 545,
-          "languages": {
-              "km": {
-                  "displayName": "Central Khmer",
-                  "languageName": "Central Khmer"
-              }
-          },
-          "authorEmail": "support@tavultesoft.com",
-          "sourcePath": "legacy/kbd/kbdkhmr",
-          "packageFileSize": 110334,
-          "deprecated": true,
-          "match": {
-              "name": "Khmer",
-              "type": "language",
-              "weight": "160",
-              "downloads": "0",
-              "final_weight": "160.0"
-          }
-      }
-  ]
+    "keyboards": [
+        {
+            "license": "mit",
+            "languages": {
+                "km": {
+                    "font": {
+                        "family": "Mondulkiri",
+                        "source": [
+                            "Mondulkiri-R.ttf"
+                        ]
+                    },
+                    "displayName": "Central Khmer",
+                    "languageName": "Central Khmer"
+                }
+            },
+            "description": "<p>Khmer Unicode keyboard layout based on the NiDA keyboard layout. Automatically corrects many common keying errors.</p>",
+            "related": {
+                "khmer10": {
+                    "deprecates": true
+                }
+            },
+            "id": "khmer_angkor",
+            "name": "Khmer Angkor",
+            "authorName": "Makara Sok",
+            "authorEmail": "makara@keyman.com",
+            "lastModifiedDate": "2020-06-12T00:39:43.475Z",
+            "sourcePath": "release/k/khmer_angkor",
+            "version": "1.0.6",
+            "packageFilename": "khmer_angkor.kmp",
+            "jsFilename": "khmer_angkor.js",
+            "encodings": [
+                "unicode"
+            ],
+            "jsFileSize": 63881,
+            "packageFileSize": 2639344,
+            "packageIncludes": [
+                "visualKeyboard",
+                "welcome",
+                "fonts",
+                "documentation"
+            ],
+            "minKeymanVersion": "10.0",
+            "helpLink": "https://help.keyman.com/keyboard/khmer_angkor",
+            "platformSupport": {
+                "windows": "full",
+                "macos": "full",
+                "linux": "full",
+                "android": "full",
+                "ios": "full",
+                "desktopWeb": "full",
+                "mobileWeb": "full"
+            },
+            "match": {
+                "name": "Khmer",
+                "type": "language",
+                "weight": "210",
+                "downloads": "37",
+                "final_weight": "973.89309354254101"
+            }
+        },
+        {
+            "license": "mit",
+            "description": "This keyboard is designed for any languages using the Khmer script. This keyboard is very similar to the Khmer ABS keyboard, but it is a Unicode keyboard.",
+            "id": "sil_khmer",
+            "languages": {
+                "km": {
+                    "displayName": "Central Khmer",
+                    "languageName": "Central Khmer"
+                },
+                "brb-khmr": {
+                    "displayName": "Lave (Khmer)",
+                    "languageName": "Lave",
+                    "scriptName": "Khmer"
+                },
+                "cmo-khmr": {
+                    "displayName": "Central Mnong (Khmer)",
+                    "languageName": "Central Mnong",
+                    "scriptName": "Khmer"
+                },
+                "jra-khmr": {
+                    "displayName": "Jarai (Khmer)",
+                    "languageName": "Jarai",
+                    "scriptName": "Khmer"
+                },
+                "kdt-khmr": {
+                    "displayName": "Kuy (Khmer)",
+                    "languageName": "Kuy",
+                    "scriptName": "Khmer"
+                },
+                "krr-khmr": {
+                    "displayName": "Krung (Khmer)",
+                    "languageName": "Krung",
+                    "scriptName": "Khmer"
+                },
+                "krv-khmr": {
+                    "displayName": "Kavet (Khmer)",
+                    "languageName": "Kavet",
+                    "scriptName": "Khmer"
+                },
+                "kxm-khmr": {
+                    "displayName": "Northern Khmer (Khmer)",
+                    "languageName": "Northern Khmer",
+                    "scriptName": "Khmer"
+                },
+                "tpu-khmr": {
+                    "displayName": "Tampuan (Khmer)",
+                    "languageName": "Tampuan",
+                    "scriptName": "Khmer"
+                }
+            },
+            "name": "Khmer (SIL)",
+            "lastModifiedDate": "2020-06-12T00:41:17.251Z",
+            "sourcePath": "release/sil/sil_khmer",
+            "version": "1.5",
+            "packageFilename": "sil_khmer.kmp",
+            "jsFilename": "sil_khmer.js",
+            "encodings": [
+                "unicode"
+            ],
+            "jsFileSize": 20855,
+            "packageFileSize": 98179,
+            "packageIncludes": [
+                "documentation",
+                "visualKeyboard",
+                "welcome"
+            ],
+            "minKeymanVersion": "10.0",
+            "helpLink": "https://help.keyman.com/keyboard/sil_khmer",
+            "platformSupport": {
+                "windows": "full",
+                "macos": "full",
+                "linux": "full",
+                "android": "full",
+                "ios": "full",
+                "desktopWeb": "full",
+                "mobileWeb": "full"
+            },
+            "match": {
+                "name": "Khmer",
+                "type": "language",
+                "weight": "356",
+                "downloads": "3",
+                "final_weight": "849.52079255868114"
+            }
+        },
+        {
+            "license": "mit",
+            "description": "Khmer (NIDA) Basic generated from template",
+            "id": "basic_kbdkni",
+            "languages": {
+                "km": {
+                    "displayName": "Central Khmer",
+                    "languageName": "Central Khmer"
+                }
+            },
+            "name": "Khmer (NIDA) Basic",
+            "lastModifiedDate": "2020-06-12T00:36:29.888Z",
+            "sourcePath": "release/basic/basic_kbdkni",
+            "version": "1.0",
+            "packageFilename": "basic_kbdkni.kmp",
+            "jsFilename": "basic_kbdkni.js",
+            "encodings": [
+                "unicode"
+            ],
+            "jsFileSize": 17913,
+            "packageFileSize": 401287,
+            "packageIncludes": [
+                "visualKeyboard",
+                "documentation",
+                "welcome",
+                "fonts"
+            ],
+            "minKeymanVersion": "10.0",
+            "helpLink": "https://help.keyman.com/keyboard/basic_kbdkni",
+            "platformSupport": {
+                "windows": "full",
+                "macos": "full",
+                "linux": "full",
+                "android": "full",
+                "ios": "full",
+                "desktopWeb": "full",
+                "mobileWeb": "full"
+            },
+            "match": {
+                "name": "Khmer",
+                "type": "language",
+                "weight": "185",
+                "downloads": "21",
+                "final_weight": "756.84285387128853"
+            }
+        },
+        {
+            "license": "mit",
+            "description": "This keyboard layout is designed for Khmer.  It includes an on screen keyboard which can be viewed by clicking on the Keyman icon and selecting the On Screen Keyboard menu item. The keyboard layout follows the Windows 10 Khmer layout.",
+            "related": {
+                "kbdkhmr": {
+                    "deprecates": true
+                }
+            },
+            "id": "basic_kbdkhmr",
+            "languages": {
+                "km": {
+                    "displayName": "Central Khmer",
+                    "languageName": "Central Khmer"
+                }
+            },
+            "name": "Khmer Basic",
+            "lastModifiedDate": "2020-06-12T00:36:29.171Z",
+            "sourcePath": "release/basic/basic_kbdkhmr",
+            "version": "1.1",
+            "packageFilename": "basic_kbdkhmr.kmp",
+            "jsFilename": "basic_kbdkhmr.js",
+            "encodings": [
+                "unicode"
+            ],
+            "jsFileSize": 16286,
+            "packageFileSize": 70886,
+            "packageIncludes": [
+                "visualKeyboard",
+                "documentation",
+                "welcome"
+            ],
+            "minKeymanVersion": "10.0",
+            "helpLink": "https://help.keyman.com/keyboard/basic_kbdkhmr",
+            "platformSupport": {
+                "windows": "full",
+                "macos": "full",
+                "linux": "full",
+                "desktopWeb": "full",
+                "mobileWeb": "full"
+            },
+            "match": {
+                "name": "Khmer",
+                "type": "language",
+                "weight": "185",
+                "downloads": "1",
+                "final_weight": "313.23222840358989"
+            }
+        },
+        {
+            "license": "mit",
+            "description": "Krung is a language spoken in the northern part of Cambodia. Khmer script was adopted and used for this language. This Keyman keyboard was developed based on an existing tool (Clever Rabit) which used the Romanized version of Krung. However, a few customizations have been made to make this keyboard perform as expected. See the documentation on the romanization and examples in our welcome page.",
+            "id": "krung",
+            "languages": {
+                "krr-khmr": {
+                    "displayName": "Krung (Khmer)",
+                    "languageName": "Krung",
+                    "scriptName": "Khmer"
+                }
+            },
+            "name": "Krung",
+            "lastModifiedDate": "2020-06-12T00:39:45.105Z",
+            "sourcePath": "release/k/krung",
+            "version": "1.0.1",
+            "packageFilename": "krung.kmp",
+            "jsFilename": "krung.js",
+            "encodings": [
+                "unicode"
+            ],
+            "jsFileSize": 117392,
+            "packageFileSize": 1324624,
+            "packageIncludes": [
+                "visualKeyboard",
+                "documentation",
+                "welcome",
+                "fonts"
+            ],
+            "minKeymanVersion": "10.0",
+            "helpLink": "https://help.keyman.com/keyboard/krung",
+            "platformSupport": {
+                "windows": "full",
+                "macos": "full",
+                "linux": "full",
+                "android": "full",
+                "ios": "full",
+                "desktopWeb": "full",
+                "mobileWeb": "full"
+            },
+            "match": {
+                "name": null,
+                "type": "description",
+                "weight": "10",
+                "downloads": "1",
+                "final_weight": "16.931471805599454"
+            }
+        },
+        {
+            "id": "khmer10",
+            "name": "NiDA Khmer",
+            "description": "Khmer Unicode keyboard layout using the NiDA keyboard layout.",
+            "authorName": "Andrew Cunningham",
+            "license": "freeware",
+            "lastModifiedDate": "2007-02-08T13:43:29Z",
+            "links": [],
+            "packageFilename": "khmer10.kmp",
+            "encodings": [
+                "unicode"
+            ],
+            "packageIncludes": [
+                "fonts",
+                "visualKeyboard"
+            ],
+            "version": "1.0",
+            "minKeymanVersion": "5.0",
+            "platformSupport": {
+                "windows": "full",
+                "desktopWeb": "full",
+                "ios": "basic",
+                "android": "basic",
+                "macos": "full"
+            },
+            "legacyId": 401,
+            "jsFilename": "khmer10.js",
+            "documentationFilename": "khmer10.html",
+            "languages": {
+                "km": {
+                    "displayName": "Central Khmer",
+                    "languageName": "Central Khmer"
+                }
+            },
+            "sourcePath": "legacy/k/khmer10",
+            "jsFileSize": 11824,
+            "packageFileSize": 110008,
+            "documentationFileSize": 22745,
+            "helpLink": "https://help.keyman.com/keyboard/khmer10",
+            "deprecated": true,
+            "match": {
+                "name": "Khmer",
+                "type": "language",
+                "weight": "210",
+                "downloads": "0",
+                "final_weight": "210.0"
+            }
+        },
+        {
+            "id": "kbdkhmr",
+            "name": "Khmer Basic",
+            "description": "This keyboard layout is designed for Khmer.  It includes an on screen keyboard which can be viewed by clicking on the Keyman icon and selecting the On Screen Keyboard menu item. The package also includes the Khmer font <b>Khmer OS</b>. The keyboard layout follows the Windows Vista Khmer layout.",
+            "authorName": "Tavultesoft",
+            "license": "freeware",
+            "lastModifiedDate": "2013-02-18T11:24:02Z",
+            "links": [],
+            "packageFilename": "kbdkhmr.kmp",
+            "encodings": [
+                "unicode"
+            ],
+            "packageIncludes": [
+                "fonts",
+                "visualKeyboard",
+                "welcome"
+            ],
+            "version": "1.0.1",
+            "minKeymanVersion": "7.0",
+            "platformSupport": {
+                "windows": "full",
+                "macos": "full"
+            },
+            "legacyId": 545,
+            "languages": {
+                "km": {
+                    "displayName": "Central Khmer",
+                    "languageName": "Central Khmer"
+                }
+            },
+            "authorEmail": "support@tavultesoft.com",
+            "sourcePath": "legacy/kbd/kbdkhmr",
+            "packageFileSize": 110334,
+            "deprecated": true,
+            "match": {
+                "name": "Khmer",
+                "type": "language",
+                "weight": "185",
+                "downloads": "0",
+                "final_weight": "185.0"
+            }
+        }
+    ],
+    "context": {
+        "range": "Keyboards matching 'khmer'",
+        "text": "khmer",
+        "pageSize": 10,
+        "pageNumber": 1,
+        "totalRows": 7,
+        "totalPages": 1
+    }
 }

--- a/tools/db/build/sp_keyboard_search.sql
+++ b/tools/db/build/sp_keyboard_search.sql
@@ -42,7 +42,7 @@ AS
     name as name,
     case
       when name = @name or name_kd = @name then @weight_factor_exact_match -- exact match gets 3x weight factor
-      else 1 -- otherwise same weight
+      else 3-log10(len(name)) -- otherwise give slightly greater weight to shorter matches
     end * @weight_langtag as weight,
     name as match_name,
     'language' as match_type

--- a/tools/db/build/sp_keyboard_search_by_id.sql
+++ b/tools/db/build/sp_keyboard_search_by_id.sql
@@ -17,6 +17,7 @@ BEGIN
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 * (LOG(COALESCE(kd.count+1, 1))+1) final_weight,
+    null match_tag,
 
     k.keyboard_id,
     k.name,

--- a/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
+++ b/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
@@ -41,6 +41,7 @@ BEGIN
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 * (LOG(COALESCE(kd.count+1, 1))+1) final_weight,
+    @varTag match_tag,
     k.keyboard_id,
     k.name,
     k.author_name,

--- a/tools/db/build/sp_keyboard_search_by_legacy_id.sql
+++ b/tools/db/build/sp_keyboard_search_by_legacy_id.sql
@@ -16,6 +16,7 @@ CREATE PROCEDURE sp_keyboard_search_by_legacy_id (
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 final_weight,
+    null match_tag,
 
     k.keyboard_id,
     k.name,


### PR DESCRIPTION
Give higher weight to shorter matches, so 'spa' matches 'Spanish' rather than a variant name. Do this only for language names