### PR TITLE
fix: schema value types for match fields

### DIFF
--- a/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json
+++ b/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json
@@ -42,8 +42,7 @@
       },
       "required": [
         "license", "languages"
-      ],
-      "additionalProperties": false
+      ]
     },
 
     "KeyboardLanguageInfo": {

--- a/schemas/search/2.0/search.json
+++ b/schemas/search/2.0/search.json
@@ -36,7 +36,13 @@
               "type": "object",
               "properties": {
                 "name": { "oneOf": [ { "type": "string" }, { "type": "null"} ] },
-                "type": { "type": "string" },
+                "type": { "type": "string", "enum": [
+                  "keyboard", "keyboard_id", "description", "legacy_keyboard_id",
+                  "language", "language_bcp47_tag",
+                  "country", "country_iso3166_code",
+                  "script", "script_iso15924_code"
+                ] },
+                "tag": { "type": "string" },
                 "weight": { "type": "number" },
                 "downloads": { "type": "number" },
                 "finalWeight": { "type": "number" }

--- a/schemas/search/2.0/search.json
+++ b/schemas/search/2.0/search.json
@@ -23,17 +23,29 @@
         "totalRows": { "type": "number" },
         "totalPages": { "type": "number" }
       },
-      "required": ["range", "text", "pageSize", "pageNumber", "totalRows", "totalPages"]
+      "required": ["range", "text", "pageSize", "pageNumber", "totalRows", "totalPages"],
+      "additionalProperties": false
     },
 
     "SearchKeyboard": {
-      "anyOf": [
+      "allOf": [
         { "$ref": "/keyboard_info.source/1.0.6/keyboard_info.source.json#/definitions/KeyboardInfo" },
         {
-          "type": "object",
           "properties": {
-            "match": { "type": "object" }
-          }
+            "match": {
+              "type": "object",
+              "properties": {
+                "name": { "oneOf": [ { "type": "string" }, { "type": "null"} ] },
+                "type": { "type": "string" },
+                "weight": { "type": "number" },
+                "downloads": { "type": "number" },
+                "finalWeight": { "type": "number" }
+              },
+              "required": ["name","type","weight","downloads","finalWeight"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["match"]
         }
       ]
     }

--- a/script/search/2.0/search.inc.php
+++ b/script/search/2.0/search.inc.php
@@ -275,6 +275,10 @@
           'finalWeight' => floatval($row['final_weight'])
         ];
 
+        // TODO: when searching for country or script, then we get a fairly 'random' first match
+        //       Is there any way we can improve this?
+        if(!empty($row['match_tag'])) $rowdata->match['tag'] = $row['match_tag'];
+
         array_push($result->keyboards, $rowdata);
       }
 

--- a/script/search/2.0/search.inc.php
+++ b/script/search/2.0/search.inc.php
@@ -270,9 +270,9 @@
         $rowdata->match = [
           'name' => $row['match_name'],
           'type' => $row['match_type'],
-          'weight' => $row['match_weight'],
-          'downloads' => $row['download_count'],
-          'final_weight' => $row['final_weight']
+          'weight' => floatval($row['match_weight']),
+          'downloads' => intval($row['download_count']),
+          'finalWeight' => floatval($row['final_weight'])
         ];
 
         array_push($result->keyboards, $rowdata);

--- a/tests/fixtures/Search.2.0.ethiopic.json
+++ b/tests/fixtures/Search.2.0.ethiopic.json
@@ -99,6 +99,7 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
+                "tag": "tig",
                 "weight": 30,
                 "downloads": 470,
                 "finalWeight": 214.64574282049253
@@ -162,6 +163,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti-ER",
                 "weight": 30,
                 "downloads": 234,
                 "finalWeight": 193.78756542432478
@@ -228,6 +230,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 226,
                 "finalWeight": 192.74850052444208
@@ -325,6 +328,7 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
+                "tag": "tig",
                 "weight": 30,
                 "downloads": 149,
                 "finalWeight": 180.31905882288765
@@ -375,6 +379,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -425,6 +430,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -508,6 +514,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -556,6 +563,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -604,6 +612,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -646,6 +655,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0

--- a/tests/fixtures/Search.2.0.ethiopic.json
+++ b/tests/fixtures/Search.2.0.ethiopic.json
@@ -99,9 +99,9 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
-                "weight": "30",
-                "downloads": "470",
-                "final_weight": "214.64574282049253"
+                "weight": 30,
+                "downloads": 470,
+                "finalWeight": 214.64574282049253
             }
         },
         {
@@ -162,9 +162,9 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "234",
-                "final_weight": "193.78756542432478"
+                "weight": 30,
+                "downloads": 234,
+                "finalWeight": 193.78756542432478
             }
         },
         {
@@ -228,9 +228,9 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "226",
-                "final_weight": "192.74850052444208"
+                "weight": 30,
+                "downloads": 226,
+                "finalWeight": 192.74850052444208
             }
         },
         {
@@ -325,9 +325,9 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
-                "weight": "30",
-                "downloads": "149",
-                "final_weight": "180.31905882288765"
+                "weight": 30,
+                "downloads": 149,
+                "finalWeight": 180.31905882288765
             }
         },
         {
@@ -375,9 +375,9 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -425,9 +425,9 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -508,9 +508,9 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -556,9 +556,9 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -604,9 +604,9 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         },
         {
@@ -646,9 +646,9 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "weight": "30",
-                "downloads": "0",
-                "final_weight": "30.0"
+                "weight": 30,
+                "downloads": 0,
+                "finalWeight": 30.0
             }
         }
    ]

--- a/tests/fixtures/Search.2.0.khmer-angkor.json
+++ b/tests/fixtures/Search.2.0.khmer-angkor.json
@@ -62,9 +62,9 @@
             "match": {
                 "name": "Khmer Angkor",
                 "type": "keyboard",
-                "weight": "90",
-                "downloads": "37",
-                "final_weight": "417.3827543753747"
+                "weight": 90,
+                "downloads": 37,
+                "finalWeight": 417.3827543753747
             }
         }
     ]

--- a/tests/fixtures/Search.2.0.khmer-keyboards.json
+++ b/tests/fixtures/Search.2.0.khmer-keyboards.json
@@ -62,9 +62,9 @@
             "match": {
                 "name": "Khmer Angkor",
                 "type": "keyboard",
-                "weight": "60",
-                "downloads": "37",
-                "final_weight": "278.25516958358315"
+                "weight": 60,
+                "downloads": 37,
+                "finalWeight": 278.25516958358315
             }
         },
         {
@@ -108,9 +108,9 @@
             "match": {
                 "name": "Khmer (NIDA) Basic",
                 "type": "keyboard",
-                "weight": "35",
-                "downloads": "21",
-                "final_weight": "143.18648586754105"
+                "weight": 35,
+                "downloads": 21,
+                "finalWeight": 143.18648586754105
             }
         },
         {
@@ -193,9 +193,9 @@
             "match": {
                 "name": "Khmer (SIL)",
                 "type": "keyboard",
-                "weight": "35",
-                "downloads": "3",
-                "final_weight": "83.520302639196174"
+                "weight": 35,
+                "downloads": 3,
+                "finalWeight": 83.520302639196174
             }
         },
         {
@@ -241,9 +241,9 @@
             "match": {
                 "name": "Khmer Basic",
                 "type": "keyboard",
-                "weight": "35",
-                "downloads": "1",
-                "final_weight": "59.260151319598087"
+                "weight": 35,
+                "downloads": 1,
+                "finalWeight": 59.260151319598087
             }
         },
         {
@@ -288,9 +288,9 @@
             "match": {
                 "name": null,
                 "type": "description",
-                "weight": "5",
-                "downloads": "1",
-                "final_weight": "8.465735902799727"
+                "weight": 5,
+                "downloads": 1,
+                "finalWeight": 8.465735902799727
             }
         },
         {
@@ -336,9 +336,9 @@
             "match": {
                 "name": "NiDA Khmer",
                 "type": "keyboard",
-                "weight": "60",
-                "downloads": "0",
-                "final_weight": "60.0"
+                "weight": 60,
+                "downloads": 0,
+                "finalWeight": 60.0
             }
         },
         {
@@ -378,9 +378,9 @@
             "match": {
                 "name": "Khmer Basic",
                 "type": "keyboard",
-                "weight": "35",
-                "downloads": "0",
-                "final_weight": "35.0"
+                "weight": 35,
+                "downloads": 0,
+                "finalWeight": 35.0
             }
         }
     ]

--- a/tests/fixtures/Search.2.0.khmer.json
+++ b/tests/fixtures/Search.2.0.khmer.json
@@ -54,9 +54,9 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "210",
-                "downloads": "37",
-                "final_weight": "973.89309354254101"
+                "weight": 210,
+                "downloads": 37,
+                "finalWeight": 973.89309354254101
             }
         },
         {
@@ -139,9 +139,9 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "356",
-                "downloads": "3",
-                "final_weight": "849.52079255868114"
+                "weight": 356,
+                "downloads": 3,
+                "finalWeight": 849.52079255868114
             }
         },
         {
@@ -185,9 +185,9 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "185",
-                "downloads": "21",
-                "final_weight": "756.84285387128853"
+                "weight": 185,
+                "downloads": 21,
+                "finalWeight": 756.84285387128853
             }
         },
         {
@@ -233,9 +233,9 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "185",
-                "downloads": "1",
-                "final_weight": "313.23222840358989"
+                "weight": 185,
+                "downloads": 1,
+                "finalWeight": 313.23222840358989
             }
         },
         {
@@ -280,9 +280,9 @@
             "match": {
                 "name": null,
                 "type": "description",
-                "weight": "10",
-                "downloads": "1",
-                "final_weight": "16.931471805599454"
+                "weight": 10,
+                "downloads": 1,
+                "finalWeight": 16.931471805599454
             }
         },
         {
@@ -328,9 +328,9 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "210",
-                "downloads": "0",
-                "final_weight": "210.0"
+                "weight": 210,
+                "downloads": 0,
+                "finalWeight": 210.0
             }
         },
         {
@@ -370,9 +370,9 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
-                "weight": "185",
-                "downloads": "0",
-                "final_weight": "185.0"
+                "weight": 185,
+                "downloads": 0,
+                "finalWeight": 185.0
             }
         }
     ],

--- a/tests/fixtures/Search.2.0.khmer.json
+++ b/tests/fixtures/Search.2.0.khmer.json
@@ -54,6 +54,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 210,
                 "downloads": 37,
                 "finalWeight": 973.89309354254101
@@ -139,6 +140,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 356,
                 "downloads": 3,
                 "finalWeight": 849.52079255868114
@@ -185,6 +187,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 185,
                 "downloads": 21,
                 "finalWeight": 756.84285387128853
@@ -233,6 +236,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 185,
                 "downloads": 1,
                 "finalWeight": 313.23222840358989
@@ -328,6 +332,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 210,
                 "downloads": 0,
                 "finalWeight": 210.0
@@ -370,6 +375,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 185,
                 "downloads": 0,
                 "finalWeight": 185.0

--- a/tools/db/build/sp_keyboard_search_by_id.sql
+++ b/tools/db/build/sp_keyboard_search_by_id.sql
@@ -17,6 +17,7 @@ BEGIN
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 * (LOG(COALESCE(kd.count+1, 1))+1) final_weight,
+    null match_tag,
 
     k.keyboard_id,
     k.name,

--- a/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
+++ b/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
@@ -41,6 +41,7 @@ BEGIN
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 * (LOG(COALESCE(kd.count+1, 1))+1) final_weight,
+    @varTag match_tag,
     k.keyboard_id,
     k.name,
     k.author_name,

--- a/tools/db/build/sp_keyboard_search_by_legacy_id.sql
+++ b/tools/db/build/sp_keyboard_search_by_legacy_id.sql
@@ -16,6 +16,7 @@ CREATE PROCEDURE sp_keyboard_search_by_legacy_id (
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 final_weight,
+    null match_tag,
 
     k.keyboard_id,
     k.name,


### PR DESCRIPTION
Improves schema validation and fixes the field types for the match object.

Then, tidy up fixtures to match the tweaked schema requirements.

Removing `additionalProperties` from keyboard_info.source.json means we can extend the schema as we do with the search schema -- and in other places, potentially. It may be worthwhile at some point defining a base schema file for the various types we have scattered around api.keyman.com, where `additionalProperties` is never specified, and refactoring the schema definitions to refer to those base schema types instead. But this is a sizeable chunk of work for limited end-user benefit...