### PR TITLE
feat: add bcp47 tag for language results

### DIFF
--- a/schemas/search/2.0/search.json
+++ b/schemas/search/2.0/search.json
@@ -36,7 +36,13 @@
               "type": "object",
               "properties": {
                 "name": { "oneOf": [ { "type": "string" }, { "type": "null"} ] },
-                "type": { "type": "string" },
+                "type": { "type": "string", "enum": [
+                  "keyboard", "keyboard_id", "description", "legacy_keyboard_id",
+                  "language", "language_bcp47_tag",
+                  "country", "country_iso3166_code",
+                  "script", "script_iso15924_code"
+                ] },
+                "tag": { "type": "string" },
                 "weight": { "type": "number" },
                 "downloads": { "type": "number" },
                 "finalWeight": { "type": "number" }

--- a/script/search/2.0/search.inc.php
+++ b/script/search/2.0/search.inc.php
@@ -275,6 +275,10 @@
           'finalWeight' => floatval($row['final_weight'])
         ];
 
+        // TODO: when searching for country or script, then we get a fairly 'random' first match
+        //       Is there any way we can improve this?
+        if(!empty($row['match_tag'])) $rowdata->match['tag'] = $row['match_tag'];
+
         array_push($result->keyboards, $rowdata);
       }
 

--- a/tests/fixtures/Search.2.0.ethiopic.json
+++ b/tests/fixtures/Search.2.0.ethiopic.json
@@ -99,6 +99,7 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
+                "tag": "tig",
                 "weight": 30,
                 "downloads": 470,
                 "finalWeight": 214.64574282049253
@@ -162,6 +163,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti-ER",
                 "weight": 30,
                 "downloads": 234,
                 "finalWeight": 193.78756542432478
@@ -228,6 +230,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 226,
                 "finalWeight": 192.74850052444208
@@ -325,6 +328,7 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
+                "tag": "tig",
                 "weight": 30,
                 "downloads": 149,
                 "finalWeight": 180.31905882288765
@@ -375,6 +379,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -425,6 +430,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -508,6 +514,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -556,6 +563,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -604,6 +612,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0
@@ -646,6 +655,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
+                "tag": "ti",
                 "weight": 30,
                 "downloads": 0,
                 "finalWeight": 30.0

--- a/tests/fixtures/Search.2.0.khmer.json
+++ b/tests/fixtures/Search.2.0.khmer.json
@@ -54,6 +54,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 210,
                 "downloads": 37,
                 "finalWeight": 973.89309354254101
@@ -139,6 +140,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 356,
                 "downloads": 3,
                 "finalWeight": 849.52079255868114
@@ -185,6 +187,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 185,
                 "downloads": 21,
                 "finalWeight": 756.84285387128853
@@ -233,6 +236,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 185,
                 "downloads": 1,
                 "finalWeight": 313.23222840358989
@@ -328,6 +332,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 210,
                 "downloads": 0,
                 "finalWeight": 210.0
@@ -370,6 +375,7 @@
             "match": {
                 "name": "Khmer",
                 "type": "language",
+                "tag": "km",
                 "weight": 185,
                 "downloads": 0,
                 "finalWeight": 185.0

--- a/tools/db/build/sp_keyboard_search_by_id.sql
+++ b/tools/db/build/sp_keyboard_search_by_id.sql
@@ -17,6 +17,7 @@ BEGIN
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 * (LOG(COALESCE(kd.count+1, 1))+1) final_weight,
+    null match_tag,
 
     k.keyboard_id,
     k.name,

--- a/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
+++ b/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
@@ -41,6 +41,7 @@ BEGIN
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 * (LOG(COALESCE(kd.count+1, 1))+1) final_weight,
+    @varTag match_tag,
     k.keyboard_id,
     k.name,
     k.author_name,

--- a/tools/db/build/sp_keyboard_search_by_legacy_id.sql
+++ b/tools/db/build/sp_keyboard_search_by_legacy_id.sql
@@ -16,6 +16,7 @@ CREATE PROCEDURE sp_keyboard_search_by_legacy_id (
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 final_weight,
+    null match_tag,
 
     k.keyboard_id,
     k.name,


### PR DESCRIPTION
This will allow us to link the language tag in automatically when installing a keyboard so the correct association is made.

Part of solution for keymanapp/keyman#1456.