### PR TITLE
feat: support custom language names and tags

### DIFF
--- a/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json
+++ b/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json
@@ -28,7 +28,7 @@
         "encodings": { "type": "array", "items": { "type": "string", "enum": ["ansi", "unicode"] }, "additionalItems": false },
         "packageIncludes": { "type": "array", "items": { "type": "string", "enum": ["welcome", "documentation", "fonts", "visualKeyboard"] }, "additionalItems": false },
         "version": { "type": "string" },
-        "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.0$" },
+        "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.\\d$" },
         "helpLink": { "type": "string", "pattern": "^https://help\\.keyman\\.com/keyboard/" },
         "platformSupport": { "$ref": "#/definitions/KeyboardPlatformInfo" },
         "legacyId": { "type": "number" },

--- a/tests/Search20Test.php
+++ b/tests/Search20Test.php
@@ -261,5 +261,14 @@ namespace Keyman\Site\com\keyman\api\tests {
       $this->assertEquals('heidelberginputsolution', $json->keyboards[0]->id);
       $this->assertEquals('isis', $json->keyboards[1]->id);
     }
+
+    public function testSearchByPopularity()
+    {
+      $json = $this->s->GetSearchMatches(null, 'p:*', 1);
+      $json = json_decode(json_encode($json));
+      $this->schema->in($json);
+      $this->assertEquals(659, $json->context->totalRows);
+      $this->assertEquals('gff_amharic', $json->keyboards[0]->id);
+    }
   }
 }

--- a/tests/Search20Test.php
+++ b/tests/Search20Test.php
@@ -245,5 +245,21 @@ namespace Keyman\Site\com\keyman\api\tests {
       $this->assertEquals('burushaski_girminas', $json->keyboards[2]->id);
       $this->assertEquals('khowar', $json->keyboards[3]->id);
     }
+
+    /**
+     * The langtags database does not include 'pi' (Pali) without a script tag.
+     * (This is not a helpful tag, but it's good for testing at this time; it is likely that
+     * an update to the keyboard will correct the tag at which point we should perhaps switch
+     * to a qa? tag.)
+     */
+    public function testSearchByCustomLanguageTag2()
+    {
+      $json = $this->s->GetSearchMatches(null, 'l:id:pi', 1);
+      $json = json_decode(json_encode($json));
+      $this->schema->in($json);
+      $this->assertEquals(2, $json->context->totalRows);
+      $this->assertEquals('heidelberginputsolution', $json->keyboards[0]->id);
+      $this->assertEquals('isis', $json->keyboards[1]->id);
+    }
   }
 }

--- a/tests/Search20Test.php
+++ b/tests/Search20Test.php
@@ -199,5 +199,51 @@ namespace Keyman\Site\com\keyman\api\tests {
       $this->assertEquals(42, $json->context->totalRows);
       $this->assertEquals('sil_ethiopic', $json->keyboards[0]->id);
     }
+
+    /**
+     * The langtags database includes 'Central Bontoc' but sil_philippines adds an alternative
+     * spelling of 'Central Bontok'
+     */
+    public function testSearchByCustomLanguageName()
+    {
+      $json = $this->s->GetSearchMatches(null, 'Central Bontok', 1);
+      $json = json_decode(json_encode($json));
+      $this->schema->in($json);
+      $this->assertEquals(1, $json->context->totalRows);
+      $this->assertEquals('Central Bontok', $json->context->text);
+      $this->assertEquals('sil_philippines', $json->keyboards[0]->id);
+    }
+
+    /**
+     * The langtags database includes 'khw[-Arab]' but not 'khw-Latn'.
+     * Keyboard burushaski_girmanas targets a Latin script variant of this.
+     * Test the direct search for the language tag.
+     */
+    public function testSearchByCustomLanguageTag()
+    {
+      $json = $this->s->GetSearchMatches(null, 'l:id:khw-latn', 1);
+      $json = json_decode(json_encode($json));
+      $this->schema->in($json);
+      $this->assertEquals(1, $json->context->totalRows);
+      $this->assertEquals('khw-latn', $json->context->text);
+      $this->assertEquals('burushaski_girminas', $json->keyboards[0]->id);
+    }
+
+    /**
+     * The langtags database includes 'khw[-Arab]' but not 'khw-Latn'.
+     * Keyboard burushaski_girmanas targets a Latin script variant of this.
+     * Validate that the search for 'Khowar' finds both Arabic and Latin script results
+     */
+    public function testSearchByLanguageFindsCustomTag()
+    {
+      $json = $this->s->GetSearchMatches(null, 'l:Khowar', 1);
+      $json = json_decode(json_encode($json));
+      $this->schema->in($json);
+      $this->assertEquals(4, $json->context->totalRows);
+      $this->assertEquals('rac_khowar', $json->keyboards[0]->id);
+      $this->assertEquals('sil_khowar', $json->keyboards[1]->id);
+      $this->assertEquals('burushaski_girminas', $json->keyboards[2]->id);
+      $this->assertEquals('khowar', $json->keyboards[3]->id);
+    }
   }
 }

--- a/tools/db/LangTags.php
+++ b/tools/db/LangTags.php
@@ -8,11 +8,13 @@
       TAGTYPE_ALTERNATE = 1,
       TAGTYPE_VARIANT = 2,
       TAGTYPE_WINDOWS = 3,
-      TAGTYPE_FULL = 4;
+      TAGTYPE_FULL = 4,
+      TAGTYPE_CUSTOM = 5; // created by a custom keyboard_info language entry
 
     const
       NAMETYPE_NAME = 0,
       NAMETYPE_LOCAL = 1,
       NAMETYPE_LATN = 2,
-      NAMETYPE_IANA = 3;
+      NAMETYPE_IANA = 3,
+      NAMETYPE_CUSTOM = 4; // created by a custom keyboard_info language entry
   }

--- a/tools/db/build/build_keyboards_script.inc.php
+++ b/tools/db/build/build_keyboards_script.inc.php
@@ -238,18 +238,15 @@ END;
           bcp47,
           language_id,
           region_id,
-          script_id
+          script_id,
+          description
         ) VALUES
 END;
 
       $result = '';
       foreach($this->keyboards as $keyboard) {
-        if(is_array($keyboard->languages)) {
-          $array = $keyboard->languages;
-        } else {
-          $array = array_keys(get_object_vars($keyboard->languages));
-        }
-        foreach($array as $id) {
+        assert(!is_array($keyboard->languages)); // array format was deprecated in 1.0.5, kmcomp should never generate it any more
+        foreach($keyboard->languages as $id => $language) {
           $this->parse_bcp47($id, $lang, $region, $script);
           $result .= <<<END
 $insert
@@ -257,7 +254,8 @@ $insert
               {$this->sqlv(null, strtolower($id))},
               {$this->sqlv(null, $lang)},
               {$this->sqlv(null, $region)},
-              {$this->sqlv(null, $script)});
+              {$this->sqlv(null, $script)},
+              {$this->sqlv($language, 'languageName')});
 
 GO
 

--- a/tools/db/build/langtags.sql
+++ b/tools/db/build/langtags.sql
@@ -28,7 +28,7 @@ DROP TABLE IF EXISTS t_langtag_tag;
 CREATE TABLE t_langtag_tag (
   base_tag NVARCHAR(128) NOT NULL,
   tag NVARCHAR(128) NOT NULL,
-  tagtype INT, -- 0=base_tag, 1=alternate tag, 2=variant, 3=windows, 4=full
+  tagtype INT, -- 0=base_tag, 1=alternate tag, 2=variant, 3=windows, 4=full, 5=custom(keyboard)
   foreign key (base_tag) REFERENCES t_langtag (tag)
 );
 

--- a/tools/db/build/search-prepare-data.sql
+++ b/tools/db/build/search-prepare-data.sql
@@ -33,8 +33,66 @@ update t_model
 
 --
 -- Canonicalize bcp47 codes into langtags entries
--- TODO: fixup those that are missing (https://docs.google.com/document/d/1Ox8JKE1yItW31SMNA3fJfrAsiQNh3xq_bDeFgMYzbmg/edit#)
 --
+-- Fixup those that are missing from t_langtags, first
+--
+
+-- Find those that are missing and add the names and tags as aliases of the base tag
+
+INSERT
+  t_langtag (tag, [full], iso639_3, region, regionname, name, sldr, script, windows)
+SELECT DISTINCT
+  kl.bcp47,
+  kl.bcp47,
+  null,
+  t.region,
+  t.regionname,
+  kl.description,
+  0,
+  kl.script_id,
+  kl.bcp47
+FROM
+  t_keyboard_language kl LEFT JOIN
+  t_langtag_tag tt ON kl.bcp47 = tt.tag LEFT JOIN
+  t_langtag_tag tt0 ON kl.language_id = tt0.tag LEFT JOIN
+  t_langtag t ON tt0.base_tag = t.tag
+WHERE
+  tt.tag IS NULL AND
+  tt0.tag IS NOT NULL
+
+-- Insert the tags above for searching against
+
+INSERT
+  t_langtag_tag (base_tag, tag, tagtype)
+SELECT DISTINCT
+  kl.bcp47,
+  kl.bcp47,
+  5 -- custom (keyboard) tag type
+FROM
+  t_keyboard_language kl LEFT JOIN
+  t_langtag_tag tt ON kl.bcp47 = tt.tag LEFT JOIN
+  t_langtag_tag tt0 ON kl.language_id = tt0.tag
+WHERE
+  tt.tag IS NULL AND
+  tt0.tag IS NOT NULL
+
+-- Add new names that have been defined by keyboard authors
+
+INSERT
+  t_langtag_name (tag, name, name_kd, nametype)
+SELECT DISTINCT
+  t.base_tag,
+  kl.description,
+  kl.description, -- TODO: we can't do full normalisation here, but we'll live with it for now
+  4 -- custom
+FROM
+  t_keyboard_language kl LEFT JOIN
+  t_langtag_tag t ON kl.bcp47 = t.tag LEFT JOIN
+  t_langtag_name n ON n.tag = t.base_tag AND n.name = kl.description
+WHERE
+  n._id IS NULL and t.tag is not null
+
+-- Finally, match up all the keyboards with langtags!
 
 INSERT
   t_keyboard_langtag

--- a/tools/db/build/sp_keyboard_search.sql
+++ b/tools/db/build/sp_keyboard_search.sql
@@ -184,6 +184,40 @@ AS
 GO
 
 -- #
+-- # Return list of keyboards sorted by popularity
+-- #
+DROP FUNCTION IF EXISTS f_keyboard_search_by_popularity;
+GO
+
+CREATE FUNCTION f_keyboard_search_by_popularity (
+  @prmPlatform nvarchar(32),
+  @weight_factor_exact_match int, @weight_keyboard int
+) RETURNS
+TABLE
+AS
+  return
+  select
+    k.keyboard_id as keyboard_id,
+    k.name as name,
+    @weight_keyboard as weight,
+    k.name as match_name,
+    'keyboard' as match_type,
+    null as match_tag
+  from
+    t_keyboard k
+  where
+    k.is_unicode = 1 and
+    k.deprecated = 0 and
+    ((@prmPlatform is null) or
+    (@prmPlatform = 'android' and k.platform_android > 0) or
+    (@prmPlatform = 'ios'     and k.platform_ios > 0) or
+    (@prmPlatform = 'linux'   and k.platform_linux > 0) or
+    (@prmPlatform = 'macos'   and k.platform_macos > 0) or
+    (@prmPlatform = 'web'     and k.platform_web > 0) or
+    (@prmPlatform = 'windows' and k.platform_windows > 0))
+GO
+
+-- #
 -- # Search across keyboard identifier
 -- #
 DROP FUNCTION IF EXISTS f_keyboard_search_by_id;

--- a/tools/db/build/sp_keyboard_search_by_popularity.sql
+++ b/tools/db/build/sp_keyboard_search_by_popularity.sql
@@ -1,0 +1,41 @@
+-- #
+-- # sp_keyboard_search_by_popularity
+-- #
+
+DROP PROCEDURE IF EXISTS sp_keyboard_search_by_popularity;
+GO
+
+CREATE PROCEDURE sp_keyboard_search_by_popularity
+  @prmPlatform nvarchar(32),
+  @prmPageNumber int,
+  @prmPageSize int
+AS
+BEGIN
+  SET NOCOUNT ON;
+
+  declare @tt_keyboard tt_keyboard_search_keyboard
+
+  declare @weight_langtag INT = 10
+  declare @weight_country INT = 1
+  declare @weight_script INT = 5
+  declare @weight_keyboard INT = 30
+  declare @weight_keyboard_id INT = 25
+  declare @weight_keyboard_description INT = 5
+  declare @weight_factor_exact_match INT = 3
+
+  -- #
+  -- # Search across keyboards
+  -- #
+
+  insert @tt_keyboard select * from f_keyboard_search_by_popularity(@prmPlatform, @weight_factor_exact_match, @weight_keyboard)
+
+  -- #
+  -- # Build final list of results; two result sets: summary data and current page result
+  -- #
+
+  SET NOCOUNT OFF;
+
+  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @tt_keyboard)
+  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @tt_keyboard)
+END
+GO


### PR DESCRIPTION
During import, if a bcp47 tag is found that is not in
langtags, a custom entry will be added. Similarly, if
a name is found that is not currently in langtags, it
will be added as a custom name. Tests updated accordingly.