### PR TITLE
refactor: use schemas instead of swappable databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,8 @@ jobs:
       api_keyman_com_mssql_pw: Password1!
       api_keyman_com_mssql_user: sa
       api_keyman_com_mssqlconninfo: sqlsrv:Server=(local)\KEYMANAPI; Database=
-      api_keyman_com_mssql_create_databases: true
-      api_keyman_com_mssqldb0: keyboards
-      api_keyman_com_mssqldb1: keyboards_1
+      api_keyman_com_mssql_create_database: true
+      api_keyman_com_mssqldb: keyboards
       api_keyman_com_keyboard_info_zip: https://downloads.keyman.com/data/keyboard_info.zip
       api_keyman_com_model_info_zip: https://downloads.keyman.com/data/model_info.zip
 
@@ -72,10 +71,9 @@ jobs:
         echo ^<?php > tools\db\localenv.php
         echo $mysqlpw='%api_keyman_com_mssql_pw%'; >> tools\db\localenv.php
         echo $mysqluser='%api_keyman_com_mssql_user%'; >> tools\db\localenv.php
-        echo $mssqldb0 = '%api_keyman_com_mssqldb0%'; >> tools\db\localenv.php
-        echo $mssqldb1 = '%api_keyman_com_mssqldb1%'; >> tools\db\localenv.php
+        echo $mssqldb = '%api_keyman_com_mssqldb%'; >> tools\db\localenv.php
         echo $mssqlconninfo='%api_keyman_com_mssqlconninfo%'; >> tools\db\localenv.php
-        echo $mssql_create_databases = true; >> tools\db\localenv.php
+        echo $mssql_create_database = true; >> tools\db\localenv.php
 
     #
     # Install SQL Server Developer Edition with FullText Search module

--- a/script/hooks/keyboards-build-success.php
+++ b/script/hooks/keyboards-build-success.php
@@ -3,6 +3,7 @@
   // Whenever a build completes on keymanapp/keyboards/master, rebuild the keyboard database
 
   require_once('../../tools/util.php');
+  require_once('../../tools/db/servervars.php');
 
   if(isset($_REQUEST['format'])) {
     $format = $_REQUEST['format'];
@@ -36,15 +37,27 @@
   }
 
   require_once('../../tools/db/build/build.inc.php');
+  require_once('../../tools/db/build/cjk/build.inc.php');
   require_once('../../tools/db/build/datasources.inc.php');
 
-  $DBDataSources = new DBDataSources();
+  function Build() {
+    $DBDataSources = new DBDataSources();
+    $dci = new DatabaseConnectionInfo();
+    $schema = $dci->getInactiveSchema();
 
-  BuildDatabase($DBDataSources, $mssqldb, true);
+    $B = new BuildCJKTableClass();
+    $B->BuildDatabase($DBDataSources, $dci->getDatabase(), $schema, true);
+    $B->BuildCJKTables($DBDataSources, $dci->getDatabase(), $schema, true);
 
-  if($format === 'application/json') {
-    echo json_encode(array("log" => $log));
-  } else {
-    echo $log;
+    $dci->setActiveSchema($schema);
+
+    global $format, $log;
+    if($format === 'application/json') {
+      echo json_encode(array("log" => $log));
+    } else {
+      echo $log;
+    }
   }
+
+  Build();
 ?>

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,6 +1,6 @@
 # Data files for tests
 
-Because this data takes a while to build, and is static, we build the database once when first running any test class, based on the state of the t_dbdatasources table (we test the langtags.json record). If this matches the test data, we don't rebuild. We also always run on the primary schema in the database.
+Because this data takes a while to build, and is static, we build the database once when first running any test class, based on the state of the t_dbdatasources table (we test the langtags.json record). If this matches the test data, we don't rebuild. The rebuild will occur on the active schema (it doesn't swap schemas).
 
 This means that the local database will be using test data post-test (we don't rebuild from live data), so don't forget to run tools/db/build/build_cli.php to rebuild from live data if you need it.
 

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,6 +1,6 @@
 # Data files for tests
 
-Because this data takes a while to build, and is static, we build the database once when first running any test class, based on the state of the t_dbdatasources table (we test the langtags.json record). If this matches the test data, we don't rebuild. We also always run on the first database ($mssqldb0).
+Because this data takes a while to build, and is static, we build the database once when first running any test class, based on the state of the t_dbdatasources table (we test the langtags.json record). If this matches the test data, we don't rebuild. We also always run on the primary schema in the database.
 
 This means that the local database will be using test data post-test (we don't rebuild from live data), so don't forget to run tools/db/build/build_cli.php to rebuild from live data if you need it.
 

--- a/tools/db/.gitignore
+++ b/tools/db/.gitignore
@@ -1,4 +1,4 @@
 test.php
 localenv.php
 build/cjk/*_import.sql
-activedb.txt
+activeschema.txt

--- a/tools/db/build/build.inc.php
+++ b/tools/db/build/build.inc.php
@@ -13,140 +13,184 @@
     $report_last_time = $new_time;
   }
 
-  // TODO: convert to class
+  class BuildDatabaseClass {
 
-  function BuildDatabase($DBDataSources, $mssqldb, $do_force) {
-    build_log("Building database $mssqldb");
+    protected $mssqldb, $schema;
 
-    global $report_last_time;
-    $report_last_time = microtime(true);
-
-    wakeUpDatabaseServer('master'); //$mssqldb);
-
-    $data_path = dirname(dirname(dirname(dirname(__FILE__)))) . "/.data/";
-
-    $builder = new build_sql_standards_data($DBDataSources);
-    $builder->execute($data_path, $do_force) || fail("Unable to build standards data scripts");
-
-    $builder = new build_keyboards_sql($DBDataSources);
-    $builder->execute($data_path, $do_force) || fail("Unable to build keyboards data scripts");
-
-    $builder = new build_models_sql($DBDataSources);
-    $builder->execute($data_path, $do_force) || fail("Unable to build lexical models data scripts");
-
-    $builder = new build_analytics_sql($DBDataSources);
-    $builder->execute($data_path) || fail("Unable to build analytics data scripts");
-
-    buildDBDataSources($data_path, $DBDataSources);
-
-    global $mssql_create_databases;
-    if(isset($mssql_create_databases))
-      sqlrun(dirname(__FILE__)."/create-database.sql", 'master', false);
-    sqlrun(dirname(__FILE__)."/search.sql", $mssqldb);
-    sqlrun(dirname(__FILE__)."/langtags.sql", $mssqldb);
-    sqlrun("${data_path}langtags.json.sql", $mssqldb);
-    sqlrun("${data_path}language-subtag-registry.sql", $mssqldb);
-    sqlrun("${data_path}iso639-3.sql", $mssqldb);
-    sqlrun("${data_path}iso639-3-name-index.sql", $mssqldb);
-    sqlrun("${data_path}ethnologue_language_codes.sql", $mssqldb);
-    sqlrun("${data_path}ethnologue_country_codes.sql", $mssqldb);
-    sqlrun("${data_path}ethnologue_language_index.sql", $mssqldb);
-    sqlrun("${data_path}keyboards.sql", $mssqldb);
-    sqlrun("${data_path}models.sql", $mssqldb);
-
-    if(file_exists("${data_path}analytics.sql"))
-      sqlrun("${data_path}analytics.sql", $mssqldb);
-
-    sqlrun(dirname(__FILE__)."/search-prepare-data.sql", $mssqldb);
-    sqlrun(dirname(__FILE__)."/indexes.sql", $mssqldb);
-
-    sqlrun(dirname(__FILE__)."/full-text-indexes.sql", $mssqldb, false);
-    sqlrun(dirname(__FILE__)."/search-queries.sql", $mssqldb);
-
-    // All scripts with sp_ prefixes will be automatically run
-    // TODO: progressively move all stored procedures to this structure
-    $scripts = glob(__DIR__ . '/sp_*.sql');
-    foreach($scripts as $script) {
-      sqlrun($script, $mssqldb);
+    function reportTime() {
+      // TODO: unify
+      global $report_last_time;
+      $new_time = microtime(true);
+      build_log("Timestamp: ".sprintf("%0.02f", ($new_time-$report_last_time)));
+      $report_last_time = $new_time;
     }
 
-    sqlrun(dirname(__FILE__)."/model-queries.sql", $mssqldb);
-    sqlrun(dirname(__FILE__)."/legacy-queries.sql", $mssqldb);
+    function BuildDatabase($DBDataSources, $mssqldb, $schema, $do_force) {
+      build_log("Building database $mssqldb.$schema");
 
-    sqlrun("${data_path}dbdatasources.sql", $mssqldb);
-    return true;
-  }
+      $this->mssqldb = $mssqldb;
+      $this->schema = $schema;
 
-  function buildDBDataSources($data_path, DBDataSources $DBDataSources) {
-    $sql = '';
+      global $report_last_time;
+      $report_last_time = microtime(true);
 
-    foreach($DBDataSources as $field => $value) {
-      $sql .= "\nINSERT t_dbdatasources SELECT ".sqlv($DBDataSources, $field).", ".sqlv(null, basename($DBDataSources->$field)). ", " . $DBDataSources->downloadDate($value) ."\n";
-    }
+      $this->wakeUpDatabaseServer('master'); //$mssqldb);
 
-    file_put_contents("${data_path}dbdatasources.sql", $sql);
-  }
+      $data_path = dirname(dirname(dirname(dirname(__FILE__)))) . "/.data/";
 
-  function download($url) {
-    $filename = basename($url);
-    build_log("Downloading $filename");
-    if(($data = file_get_contents($url)) === false) {
-      fail("Unable to download $url");
-    }
-    file_put_contents($filename, $data);
-    return true;
-  }
+      $builder = new build_sql_standards_data($DBDataSources, $schema);
+      $builder->execute($data_path, $do_force) || fail("Unable to build standards data scripts");
 
-  function sqlrun($sql, $db = 'master', $transaction = true) {
-    reportTime();
-    build_log("Running $sql");
-    $s = file_get_contents($sql);
-    $s = preg_split('/^\s*GO\s*$/m', $s);
+      $builder = new build_keyboards_sql($DBDataSources, $schema);
+      $builder->execute($data_path, $do_force) || fail("Unable to build keyboards data scripts");
 
-    global $mssqlconninfo, $mysqluser, $mysqlpw;
-    try {
-      $mssql = new PDO($mssqlconninfo . $db, $mysqluser, $mysqlpw, [ "CharacterSet" => "UTF-8" ]);
-      $mssql->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
-      $mssql->setAttribute( PDO::SQLSRV_ATTR_DIRECT_QUERY, true);
-      $mssql->setAttribute( PDO::SQLSRV_ATTR_ENCODING, PDO::SQLSRV_ENCODING_UTF8 );
-    }
-    catch( PDOException $e ) {
-      die( "Error connecting to SQL Server: " . $e->getMessage() );
-    }
+      $builder = new build_models_sql($DBDataSources, $schema);
+      $builder->execute($data_path, $do_force) || fail("Unable to build lexical models data scripts");
 
-    try {
-      if($transaction) $mssql->beginTransaction();
+      $builder = new build_analytics_sql($DBDataSources, $schema);
+      $builder->execute($data_path) || fail("Unable to build analytics data scripts");
 
-      foreach($s as $cmd) {
-        if(trim($cmd) == '') continue;
-        $mssql->exec($cmd);
-        //build_log("$res rows affected\n");
+      $this->buildDBDataSources($data_path, $DBDataSources);
+
+      global $mssql_create_database;
+      if(isset($mssql_create_database)) {
+        //
+        $this->createSqlLogin() || fail("Unable to create logins");
+        $this->sqlrun(dirname(__FILE__)."/create-database.sql", true, false);
       }
 
-      if($transaction) $mssql->commit();
-    } catch(PDOException $e) {
-      $ei = $mssql->errorInfo();
-      print_r($ei);
-      fail("Failure: {$e}\n\n");
-    }
-  }
+      $this->sqlrun(dirname(__FILE__)."/clean-database.sql", false, false);
 
-  function wakeUpDatabaseServer($db) {
-    global $mssqlconninfo, $mysqluser, $mysqlpw;
-    $tries = 1;
-    while(true) {
-      build_log("Attempting to wake $db (attempt $tries/5)");
+      $this->sqlrun(dirname(__FILE__)."/search.sql");
+      $this->sqlrun(dirname(__FILE__)."/langtags.sql");
+      $this->sqlrun("${data_path}langtags.json.sql");
+      $this->sqlrun("${data_path}language-subtag-registry.sql");
+      $this->sqlrun("${data_path}iso639-3.sql");
+      $this->sqlrun("${data_path}iso639-3-name-index.sql");
+      $this->sqlrun("${data_path}ethnologue_language_codes.sql");
+      $this->sqlrun("${data_path}ethnologue_country_codes.sql");
+      $this->sqlrun("${data_path}ethnologue_language_index.sql");
+      $this->sqlrun("${data_path}keyboards.sql");
+      $this->sqlrun("${data_path}models.sql");
+
+      if(file_exists("${data_path}analytics.sql"))
+        $this->sqlrun("${data_path}analytics.sql");
+
+      $this->sqlrun(dirname(__FILE__)."/search-prepare-data.sql");
+      $this->sqlrun(dirname(__FILE__)."/indexes.sql");
+
+      $this->sqlrun(dirname(__FILE__)."/full-text-indexes.sql", false, false);
+      $this->sqlrun(dirname(__FILE__)."/search-queries.sql");
+
+      // All scripts with sp_ prefixes will be automatically run
+      // TODO: progressively move all stored procedures to this structure
+      $scripts = glob(__DIR__ . '/sp_*.sql');
+      foreach($scripts as $script) {
+        $this->sqlrun($script);
+      }
+
+      $this->sqlrun(dirname(__FILE__)."/model-queries.sql");
+      $this->sqlrun(dirname(__FILE__)."/legacy-queries.sql");
+
+      $this->sqlrun("${data_path}dbdatasources.sql");
+      return true;
+    }
+
+    function buildDBDataSources($data_path, DBDataSources $DBDataSources) {
+      $sql = '';
+
+      foreach($DBDataSources as $field => $value) {
+        $sql .= "\nINSERT t_dbdatasources SELECT ".sqlv($DBDataSources, $field).", ".sqlv(null, basename($DBDataSources->$field)). ", " . $DBDataSources->downloadDate($value) ."\n";
+      }
+
+      file_put_contents("${data_path}dbdatasources.sql", $sql);
+    }
+
+    function download($url) {
+      $filename = basename($url);
+      build_log("Downloading $filename");
+      if(($data = file_get_contents($url)) === false) {
+        fail("Unable to download $url");
+      }
+      file_put_contents($filename, $data);
+      return true;
+    }
+
+    function sqlrun($sql, $useMaster = false, $transaction = true) {
+      global $mssqldb;
+
+      $this->reportTime();
+      build_log("Running $sql");
+      $s = file_get_contents($sql);
+      $s = str_replace('$keyboards', $this->mssqldb, $s);
+      $s = str_replace('$schema', $this->schema, $s);
+
+      $s = preg_split('/^\s*GO\s*$/m', $s);
+
+      global $mssqlconninfo, $mysqluser, $mysqlpw;
       try {
-        $mssql = new PDO($mssqlconninfo . $db, $mysqluser, $mysqlpw, [ "CharacterSet" => "UTF-8" ]);
-        return true;
+        $mssql = new PDO($mssqlconninfo . ($useMaster ? 'master' : $this->mssqldb),
+          ($useMaster ? $mysqluser : $this->schema), $mysqlpw,
+          [ "CharacterSet" => "UTF-8" ]);
+        $mssql->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+        $mssql->setAttribute( PDO::SQLSRV_ATTR_DIRECT_QUERY, true);
+        $mssql->setAttribute( PDO::SQLSRV_ATTR_ENCODING, PDO::SQLSRV_ENCODING_UTF8 );
       }
       catch( PDOException $e ) {
-        $tries++;
-        if($tries > 5) {
-          die( "Unable to wake SQL Server $db after 5 attempts: " . $e->getMessage() );
+        die( "Error connecting to SQL Server: " . $e->getMessage() );
+      }
+
+      try {
+        if($transaction) $mssql->beginTransaction();
+
+        foreach($s as $cmd) {
+          if(trim($cmd) == '') continue;
+          $mssql->exec($cmd);
+          //build_log("$res rows affected\n");
+        }
+
+        if($transaction) $mssql->commit();
+      } catch(PDOException $e) {
+        $ei = $mssql->errorInfo();
+        print_r($ei);
+        fail("Failure: {$e}\n\n");
+      }
+    }
+
+    function createSqlLogin() {
+      build_log("Creating database login $this->schema");
+      $dci = new DatabaseConnectionInfo();
+      $mssql = new PDO($dci->getMasterConnectionString(), $dci->getUser(), $dci->getPassword(), [ "CharacterSet" => "UTF-8" ]);
+      $mssql->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+
+      $pw = $mssql->quote($dci->getPassword());
+      // note: cannot use parameterized query due to limitations with how parameters are
+      // passed to DDL type statements
+      $stmt = $mssql->prepare("
+        IF NOT EXISTS
+          (SELECT name FROM master.sys.server_principals WHERE name = '$this->schema')
+        BEGIN
+          CREATE LOGIN [$this->schema] WITH PASSWORD = $pw
+        END");
+      return $stmt->execute();
+    }
+
+    function wakeUpDatabaseServer($db) {
+      global $mssqlconninfo, $mysqluser, $mysqlpw;
+      $tries = 1;
+      while(true) {
+        build_log("Attempting to wake $db (attempt $tries/5)");
+        try {
+          $mssql = new PDO($mssqlconninfo . $db, $mysqluser, $mysqlpw, [ "CharacterSet" => "UTF-8" ]);
+          return true;
+        }
+        catch( PDOException $e ) {
+          $tries++;
+          if($tries > 5) {
+            die( "Unable to wake SQL Server $db after 5 attempts: " . $e->getMessage() );
+          }
         }
       }
     }
   }
-
 

--- a/tools/db/build/build_cli.php
+++ b/tools/db/build/build_cli.php
@@ -18,18 +18,19 @@
 
   $log = '';
 
-  $activedb = new \ActiveDB();
-  $mssqldb = $activedb->get_swap();
+  $dci = new \DatabaseConnectionInfo();
+  $schema = $dci->getInactiveSchema();
 
   $DBDataSources = new DBDataSources();
 
+  $B = new BuildCJKTableClass();
   try {
-    BuildDatabase($DBDataSources, $mssqldb, count($argv) > 1 && $argv[1] == '-f');
-    BuildCJKTables($DBDataSources, $mssqldb, count($argv) > 1 && $argv[1] == '-f');
-    reportTime();
+    $B->BuildDatabase($DBDataSources, $mssqldb, $schema, count($argv) > 1 && $argv[1] == '-f');
+    $B->BuildCJKTables($DBDataSources, $mssqldb, $schema, count($argv) > 1 && $argv[1] == '-f');
+    $B->reportTime();
     build_log("Success");
 
-    $activedb->set($mssqldb);
+    $dci->setActiveSchema($schema);
   } catch(Exception $e) {
     fail($e->getMessage());
   }

--- a/tools/db/build/build_models_script.inc.php
+++ b/tools/db/build/build_models_script.inc.php
@@ -38,8 +38,8 @@
     }
 
     /**
-      Build a SQL script to insert model_info data into the database
-    */
+     * Build a SQL script to insert model_info data into the database
+     */
 
     private $models = array();
 
@@ -251,8 +251,8 @@ END;
     }
 
     /**
-      Generate an SQL script to insert entries in to the t_model_related table
-    */
+     * Generate an SQL script to insert entries in to the t_model_related table
+     */
     function generate_model_related_inserts() {
       $insert = <<<END
         INSERT t_model_related (

--- a/tools/db/build/build_standards_data_script.inc.php
+++ b/tools/db/build/build_standards_data_script.inc.php
@@ -56,8 +56,8 @@
 
       reportTime();
 
-      $langtags = new build_sql_standards_data_langtags($this->DBDataSources);
-        $langtags->execute($data_root, $do_force);
+      $langtags = new build_sql_standards_data_langtags($this->DBDataSources, $this->schema);
+      $langtags->execute($data_root, $do_force);
 
       return true;
     }

--- a/tools/db/build/cjk/build.inc.php
+++ b/tools/db/build/cjk/build.inc.php
@@ -2,18 +2,23 @@
   require_once(__DIR__ . '/../../servervars.php');
   require_once(__DIR__ . '/build_cjk_data_script.inc.php');
 
-  function BuildCJKTables($DBDataSources, $mssqldb, $do_force) {
-    $data_path = __DIR__ . '/';
+  // TODO: this class inheritance is rather shambolic
+  class BuildCJKTableClass extends BuildDatabaseClass {
+    function BuildCJKTables($DBDataSources, $mssqldb, $schema, $do_force) {
+      $data_path = __DIR__ . '/';
 
-    sqlrun("${data_path}cjk_database.sql", $mssqldb);
+      $this->mssqldb = $mssqldb;
+      $this->schema = $schema;
 
-    $builder = new build_cjk_data($DBDataSources);
-    $builder->execute($data_path, $do_force) || fail("Unable to build cjk data");
+      $this->sqlrun("${data_path}cjk_database.sql");
 
-    sqlrun("${data_path}chinese_pinyin_import.sql", $mssqldb);
-    sqlrun("${data_path}japanese_import.sql", $mssqldb);
+      $builder = new build_cjk_data($DBDataSources, $schema);
+      $builder->execute($data_path, $do_force) || fail("Unable to build cjk data");
 
-    return true;
+      $this->sqlrun("${data_path}chinese_pinyin_import.sql");
+      $this->sqlrun("${data_path}japanese_import.sql");
+
+      return true;
+    }
   }
-
 ?>

--- a/tools/db/build/clean-database.sql
+++ b/tools/db/build/clean-database.sql
@@ -1,0 +1,52 @@
+-- https://stackoverflow.com/a/8150428/1836776, tweaked
+
+declare @n char(1)
+set @n = char(10)
+
+declare @stmt nvarchar(max)
+
+-- procedures
+select @stmt = isnull( @stmt + @n, '' ) +
+    'drop procedure [' + schema_name(schema_id) + '].[' + name + ']'
+from sys.procedures
+where schema_id = schema_id()
+
+
+-- check constraints
+select @stmt = isnull( @stmt + @n, '' ) +
+'alter table [' + schema_name(schema_id) + '].[' + object_name( parent_object_id ) + ']    drop constraint [' + name + ']'
+from sys.check_constraints
+where schema_id = schema_id()
+
+-- functions
+select @stmt = isnull( @stmt + @n, '' ) +
+    'drop function [' + schema_name(schema_id) + '].[' + name + ']'
+from sys.objects
+where type in ( 'FN', 'IF', 'TF' ) and schema_id = schema_id()
+
+-- views
+select @stmt = isnull( @stmt + @n, '' ) +
+    'drop view [' + schema_name(schema_id) + '].[' + name + ']'
+from sys.views
+where schema_id = schema_id()
+
+-- foreign keys
+select @stmt = isnull( @stmt + @n, '' ) +
+    'alter table [' + schema_name(schema_id) + '].[' + object_name( parent_object_id ) + '] drop constraint [' + name + ']'
+from sys.foreign_keys
+where schema_id = schema_id()
+
+-- tables
+select @stmt = isnull( @stmt + @n, '' ) +
+    'drop table [' + schema_name(schema_id) + '].[' + name + ']'
+from sys.tables
+where schema_id = schema_id()
+
+-- user defined types
+select @stmt = isnull( @stmt + @n, '' ) +
+    'drop type [' + schema_name(schema_id) + '].[' + name + ']'
+from sys.types
+where is_user_defined = 1 and  schema_id = schema_id()
+
+--print @stmt
+exec sp_executesql @stmt

--- a/tools/db/build/common.inc.php
+++ b/tools/db/build/common.inc.php
@@ -127,10 +127,12 @@
 
     class build_common {
       public $force, $script_path;
+      public String $schema;
       protected DBDataSources $DBDataSources;
 
-      function __construct(DBDataSources $DBDataSources) {
+      function __construct(DBDataSources $DBDataSources, String $schema) {
         $this->DBDataSources = $DBDataSources;
+        $this->schema = $schema;
       }
 
       function sqlv($o, $p) {

--- a/tools/db/build/create-database.sql
+++ b/tools/db/build/create-database.sql
@@ -1,11 +1,20 @@
 -- We'll go ahead and create databases if they are not present, before choosing the database to populate based on the t_active setting
 
-IF DB_ID('keyboards') IS NULL
-BEGIN
-  CREATE DATABASE keyboards;
-END
+USE master;
+GO
 
-IF DB_ID('keyboards_1') IS NULL
+IF DB_ID('$keyboards') IS NULL
 BEGIN
-  CREATE DATABASE keyboards_1;
+  EXEC('CREATE DATABASE $keyboards')
 END
+GO
+
+USE $keyboards
+EXEC('CREATE SCHEMA k0')
+EXEC('CREATE SCHEMA k1')
+EXEC('CREATE USER k0 FOR LOGIN k0 WITH DEFAULT_SCHEMA=k0')
+EXEC('CREATE USER k1 FOR LOGIN k1 WITH DEFAULT_SCHEMA=k1')
+EXEC('GRANT ALL TO k0')
+EXEC('GRANT ALL TO k1')
+EXEC('ALTER ROLE db_owner ADD MEMBER k0')
+EXEC('ALTER ROLE db_owner ADD MEMBER k1')

--- a/tools/db/build/full-text-indexes.sql
+++ b/tools/db/build/full-text-indexes.sql
@@ -2,10 +2,10 @@
 -- Cleanup existing indexes
 --
 
-IF exists (select * from sys.fulltext_indexes i where i.object_id = object_id('t_langtag_name'))
+IF exists (select * from sys.fulltext_indexes i where i.object_id = object_id('t_langtag_name') and schema_id(object_schema_name(i.object_id)) = schema_id())
   DROP FULLTEXT INDEX ON t_langtag_name;
 
-IF exists (select * from sys.fulltext_indexes i where i.object_id = object_id('t_keyboard'))
+IF exists (select * from sys.fulltext_indexes i where i.object_id = object_id('t_keyboard') and schema_id(object_schema_name(i.object_id)) = schema_id())
   DROP FULLTEXT INDEX ON t_keyboard;
 
 DROP INDEX IF EXISTS ix_keyboard_id ON t_keyboard;
@@ -14,52 +14,63 @@ DROP INDEX IF EXISTS ix_region_id ON t_region;
 DROP INDEX IF EXISTS ix_script_id ON t_script;
 
 --
--- Catalog
+-- Catalog: we use a separate catalog for each schema, although it's not technically necessary,
+-- but this helps to keep the scripts completely isolated
 --
 
-if exists (select * from sys.fulltext_catalogs where name = 'c_keyboard')
-  DROP FULLTEXT CATALOG c_keyboard;
+DECLARE @stmt NVARCHAR(MAX)
 
-CREATE FULLTEXT CATALOG c_keyboard;
+if exists (select * from sys.fulltext_catalogs c where c.name = schema_name() + '_c_keyboard')
+begin
+  SET @stmt = REPLACE('DROP FULLTEXT CATALOG c_keyboard', 'c_keyboard', schema_name()+'_c_keyboard')
+  EXEC(@stmt);
+end
 
---
--- Keyboard name and description fulltext search
---
+SET @stmt = REPLACE('CREATE FULLTEXT CATALOG c_keyboard', 'c_keyboard', schema_name()+'_c_keyboard')
+EXEC(@stmt);
 
-CREATE UNIQUE INDEX ix_keyboard_id ON t_keyboard (keyboard_id);
+SET @stmt=REPLACE('
+  --
+  -- Keyboard name and description fulltext search
+  --
 
-CREATE FULLTEXT INDEX ON t_keyboard (
-  description,
-  name
-) KEY INDEX ix_keyboard_id ON c_keyboard;
+  CREATE UNIQUE INDEX ix_keyboard_id ON t_keyboard (keyboard_id);
 
---
--- Keyboard Search (Languages)
---
+  CREATE FULLTEXT INDEX ON t_keyboard (
+    description,
+    name
+  ) KEY INDEX ix_keyboard_id ON c_keyboard;
 
-CREATE UNIQUE INDEX ix_langtag_name_tag ON t_langtag_name (_id);
+  --
+  -- Keyboard Search (Languages)
+  --
 
-CREATE FULLTEXT INDEX ON t_langtag_name (
-  name,
-  name_kd
-) KEY INDEX ix_langtag_name_tag ON c_keyboard;
+  CREATE UNIQUE INDEX ix_langtag_name_tag ON t_langtag_name (_id);
 
---
--- Keyboard Search (Region)
---
+  CREATE FULLTEXT INDEX ON t_langtag_name (
+    name,
+    name_kd
+  ) KEY INDEX ix_langtag_name_tag ON c_keyboard;
 
-CREATE UNIQUE INDEX ix_region_id ON t_region (region_id);
+  --
+  -- Keyboard Search (Region)
+  --
 
-CREATE FULLTEXT INDEX ON t_region (
-  name
-) KEY INDEX ix_region_id ON c_keyboard;
+  CREATE UNIQUE INDEX ix_region_id ON t_region (region_id);
 
---
--- Keyboard Search (Script)
---
+  CREATE FULLTEXT INDEX ON t_region (
+    name
+  ) KEY INDEX ix_region_id ON c_keyboard;
 
-CREATE UNIQUE INDEX ix_script_id ON t_script (script_id);
+  --
+  -- Keyboard Search (Script)
+  --
 
-CREATE FULLTEXT INDEX ON t_script (
-  name
-) KEY INDEX ix_script_id ON c_keyboard;
+  CREATE UNIQUE INDEX ix_script_id ON t_script (script_id);
+
+  CREATE FULLTEXT INDEX ON t_script (
+    name
+  ) KEY INDEX ix_script_id ON c_keyboard;
+', 'c_keyboard', schema_name()+'_c_keyboard')
+
+EXEC(@stmt)

--- a/tools/db/build/indexes.sql
+++ b/tools/db/build/indexes.sql
@@ -23,7 +23,7 @@ The Query Processor estimates that implementing the following index could improv
 */
 
 CREATE NONCLUSTERED INDEX ix_langtag_region
-ON [dbo].[t_langtag] ([region])
+ON [t_langtag] ([region])
 INCLUDE ([name])
 
 /*
@@ -32,7 +32,7 @@ The Query Processor estimates that implementing the following index could improv
 */
 
 CREATE NONCLUSTERED INDEX ix_langtag_script
-ON [dbo].[t_langtag] ([script])
+ON [t_langtag] ([script])
 INCLUDE ([name])
 
 /*
@@ -41,7 +41,7 @@ The Query Processor estimates that implementing the following index could improv
 */
 
 CREATE NONCLUSTERED INDEX ix_keyboard_langtag_tag
-ON [dbo].[t_keyboard_langtag] ([tag])
+ON [t_keyboard_langtag] ([tag])
 INCLUDE ([keyboard_id])
 
 CREATE INDEX ix_keyboard_downloads ON t_keyboard_downloads (keyboard_id) INCLUDE (count)

--- a/tools/db/build/search.sql
+++ b/tools/db/build/search.sql
@@ -10,7 +10,8 @@ SELECT
 FROM
     sys.foreign_keys c
 WHERE
-    object_name(c.parent_object_id) LIKE 't[_]%'
+    object_name(c.parent_object_id) LIKE 't[_]%' AND
+    c.schema_id = schema_id()
 
 OPEN table_cursor
 FETCH NEXT FROM table_cursor INTO @name, @object_name

--- a/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
+++ b/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
@@ -16,7 +16,7 @@ CREATE PROCEDURE sp_keyboard_search_by_language_bcp47_tag (
 ) AS
 BEGIN
   DECLARE @varTag NVARCHAR(250)
-  SET @varTag = dbo.f_get_canonical_bcp47(@prmTag)
+  SET @varTag = $schema.f_get_canonical_bcp47(@prmTag)
 
   -- Get total rows for search
   SELECT

--- a/tools/db/db.php
+++ b/tools/db/db.php
@@ -8,14 +8,13 @@ namespace Keyman\Site\com\keyman\api\Tools\DB {
   {
     static function Connect()
     {
-      $activedb = new \ActiveDB();
+      $dci = new \DatabaseConnectionInfo();
 
-      global $mssqlconninfo, $mysqluser, $mysqlpw;
       try {
-        $mssql = new \PDO($mssqlconninfo . $activedb->get(), $mysqluser, $mysqlpw, [ "CharacterSet" => "UTF-8" ]);
+        $mssql = new \PDO($dci->getConnectionString(), $dci->getActiveSchema(), $dci->getPassword(), [ "CharacterSet" => "UTF-8" ]);
         $mssql->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
       } catch (\PDOException $e) {
-        fail("Error connecting to SQL Server", 500, "[$mssqlconninfo{$activedb->get()}]: " . $e->getMessage());
+        fail("Error connecting to SQL Server", 500, "[{$dci->getConnectionString()}]: " . $e->getMessage());
       }
       return $mssql;
     }

--- a/tools/db/servervars.php
+++ b/tools/db/servervars.php
@@ -11,45 +11,71 @@ namespace {
   if (!isset($mysqluser))
     $mysqluser = isset($_SERVER['api_keyman_com_mssql_user']) ? $_SERVER['api_keyman_com_mssql_user'] : null;
 
-  if (!isset($mssqldb0)) $mssqldb0 = $_SERVER['api_keyman_com_mssqldb0'];
-  if (!isset($mssqldb1)) $mssqldb1 = $_SERVER['api_keyman_com_mssqldb1'];
+  if (!isset($mssqldb)) $mssqldb = $_SERVER['api_keyman_com_mssqldb'];
   if (!isset($mssqlconninfo)) $mssqlconninfo = $_SERVER['api_keyman_com_mssqlconninfo'];
-  if (!isset($mssql_create_databases) && isset($_SERVER['api_keyman_com_mssql_create_databases'])) $mssql_create_databases = $_SERVER['api_keyman_com_mssql_create_databases'];
+  if (!isset($mssql_create_database) && isset($_SERVER['api_keyman_com_mssql_create_database']))
+    $mssql_create_database = $_SERVER['api_keyman_com_mssql_create_database'];
 
-  class ActiveDB
+  class DatabaseConnectionInfo
   {
-    private $active;
+    const SCHEMA0 = 'k0', SCHEMA1 = 'k1';
+
+    private $activeSchema;
+
     private function filename()
     {
-      return dirname(__FILE__) . '/activedb.txt';
+      return dirname(__FILE__) . '/activeschema.txt';
     }
 
     function __construct()
     {
-      global $mssqldb0;
       if (file_exists($this->filename())) {
-        $this->active = trim(file_get_contents($this->filename()));
+        $this->activeSchema = trim(file_get_contents($this->filename()));
       } else {
-        $this->active = $mssqldb0;
+        $this->activeSchema = self::SCHEMA0;
       }
     }
-    function get()
+
+    function getActiveSchema()
     {
-      return $this->active;
+      return $this->activeSchema;
     }
 
-    function get_swap()
+    function getInactiveSchema()
     {
-      global $mssqldb0, $mssqldb1;
-      return ($this->active == $mssqldb0) ? $mssqldb1 : $mssqldb0;
+      return $this->activeSchema == self::SCHEMA0 ? self::SCHEMA1 : self::SCHEMA0;
     }
 
-    function set($value)
+    function setActiveSchema($value)
     {
-      global $mssqldb0, $mssqldb1;
-      assert($value == $mssqldb0 || $value == $mssqldb1);
+      assert($value == self::SCHEMA0 || $value == self::SCHEMA1);
       file_put_contents($this->filename(), $value);
-      $this->active = $value;
+      $this->activeSchema = $value;
+    }
+
+    function getConnectionString() {
+      global $mssqlconninfo, $mssqldb;
+      return $mssqlconninfo . $mssqldb;
+    }
+
+    function getMasterConnectionString() {
+      global $mssqlconninfo;
+      return $mssqlconninfo . 'master';
+    }
+
+    function getDatabase() {
+      global $mssqldb;
+      return $mssqldb;
+    }
+
+    function getUser() {
+      global $mysqluser;
+      return $mysqluser;
+    }
+
+    function getPassword() {
+      global $mysqlpw;
+      return $mysqlpw;
     }
   }
 }


### PR DESCRIPTION
Relates to #87.

This reduces our database requirement to a single database, which will reduce run costs on Azure.

## Background

So a SQL Server 'schema' is effectively a namespace within a database. Objects in SQL Server are referred to with up to two qualifiers before the name: `[database_name].[schema_name].[object_name]`.

This PR is moving down our active/inactive database pairs down one level in "namespacing" from database level to schema level.

The reason we have two schemas is this way we can build a whole new database (which is entirely static data, remember), on an inactive schema, and then swap over in a single (atomic) statement, without impacting use of the database at all in the interim.

## Setup

If you have setup a local instance, you'll need to adjust the following environment variables / variables:

* `api_keyman_com_mssqldb` (`$mssqldb`) is now the database name to use
* `api_keyman_com_mssql_create_database` (`$mssql_create_database`) should be set to `true` if you want to create the database automatically during the build.