### PR TITLE
fix(search): use keyboard's BCP 47 tag in links

### DIFF
--- a/tests/Search20Test.php
+++ b/tests/Search20Test.php
@@ -153,6 +153,26 @@ namespace Keyman\Site\com\keyman\api\tests {
       $this->assertEquals('khmer10', $json->keyboards[5]->id);
     }
 
+    public function testSearchResultForKeyboardsBcp47Tag()
+    {
+      // We should return the tag from the keyboard in the match->tag field, not the normalised tag
+      $json = $this->s->GetSearchMatches(null, 'l:id:str-latn', 1);
+      $json = json_decode(json_encode($json));
+      $this->schema->in($json);
+      $this->assertEquals(3, $json->context->totalRows);
+      $this->assertEquals('fv_sencoten', $json->keyboards[0]->id);
+      $this->assertEquals('language_bcp47_tag', $json->keyboards[0]->match->type);
+      $this->assertEquals('str-latn', $json->keyboards[0]->match->tag);
+
+      $json = $this->s->GetSearchMatches(null, 'sencoten', 1);
+      $json = json_decode(json_encode($json));
+      $this->schema->in($json);
+      $this->assertEquals(3, $json->context->totalRows);
+      $this->assertEquals('fv_sencoten', $json->keyboards[0]->id);
+      $this->assertEquals('language', $json->keyboards[0]->match->type);
+      $this->assertEquals('str-latn', $json->keyboards[0]->match->tag);
+    }
+
     public function testSearchByLanguageName()
     {
       $json = $this->s->GetSearchMatches(null, 'l:Blang', 1);

--- a/tests/fixtures/Search.2.0.ethiopic.json
+++ b/tests/fixtures/Search.2.0.ethiopic.json
@@ -99,7 +99,7 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
-                "tag": "tig",
+                "tag": "tig-ethi",
                 "weight": 30,
                 "downloads": 470,
                 "finalWeight": 214.64574282049253
@@ -163,7 +163,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "tag": "ti-ER",
+                "tag": "ti-ethi-er",
                 "weight": 30,
                 "downloads": 234,
                 "finalWeight": 193.78756542432478
@@ -230,7 +230,7 @@
             "match": {
                 "name": "\u1275\u130d\u122d\u129b",
                 "type": "language",
-                "tag": "ti",
+                "tag": "ti-et",
                 "weight": 30,
                 "downloads": 226,
                 "finalWeight": 192.74850052444208
@@ -328,7 +328,7 @@
             "match": {
                 "name": "\u1275\u130d\u122b\u12ed\u1275",
                 "type": "language",
-                "tag": "tig",
+                "tag": "tig-ethi",
                 "weight": 30,
                 "downloads": 149,
                 "finalWeight": 180.31905882288765

--- a/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
+++ b/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
@@ -36,12 +36,12 @@ BEGIN
 
   -- Result matches
   SELECT
-    @varTag match_name,
+    $schema.f_keyboard_search_bcp47_for_keyboard(k.keyboard_id, @varTag) match_name,
     'language_bcp47_tag' match_type,
     1 match_weight,
     COALESCE(kd.count, 0) download_count, -- missing count record = 0 downloads over last 30 days
     1 * (LOG(COALESCE(kd.count+1, 1))+1) final_weight,
-    @varTag match_tag,
+    $schema.f_keyboard_search_bcp47_for_keyboard(k.keyboard_id, @varTag) match_tag,
     k.keyboard_id,
     k.name,
     k.author_name,


### PR DESCRIPTION
Relates to #87.

This updates the search algorithm to return the matched keyboard's registered BCP 47 tag rather than the normalised BCP 47 tag that is used for the search, in the `match.tag` field, so that the tag can be passed as a initial parameter to the apps for installing the keyboard.

This means that a search may involve up to three different forms of the same tag:

* The searched tag, e.g. `str-latn-ca`
* The normalised tag, e.g. `str`
* The keyboard's registered tag, e.g. `str-latn`

The presentation of the results hides most of these details from the user.