### PR TITLE
fix: skip deprecated keyboards

### DIFF
--- a/script/search/2.0/search.php
+++ b/script/search/2.0/search.php
@@ -44,6 +44,7 @@
 
   $query = $_REQUEST['q'];
   $platform = isset($_REQUEST['platform']) ? $_REQUEST['platform'] : null;
+  $obsolete = !empty($_REQUEST['obsolete']);
 
   if(isset($_REQUEST['p'])) {
     $pageNumber = (int)($_REQUEST['p']);
@@ -53,7 +54,7 @@
   }
 
   $s = new KeyboardSearch($mssql);
-  $json = $s->GetSearchMatches($platform, $query, $pageNumber);
+  $json = $s->GetSearchMatches($platform, $query, $obsolete, $pageNumber);
 
   if(isset($_REQUEST['f']) && !empty($_REQUEST['f']))
     json_print($json);

--- a/tests/Search20Test.php
+++ b/tests/Search20Test.php
@@ -29,7 +29,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSimpleSearchResultValidatesAgainstSchema(): void
     {
-      $json = $this->s->GetSearchMatches(null, 'thai', 1);
+      $json = $this->s->GetSearchMatches(null, 'thai', 1, 1);
 
       // Whoa, PHP does *not* round-trip JSON cleanly. This however takes our output and transforms it
       // to something that passes our schema validation
@@ -45,7 +45,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSimpleSearchResultContentsConsistent()
     {
-      $json = $this->s->GetSearchMatches(null, 'khmer', 1);
+      $json = $this->s->GetSearchMatches(null, 'khmer', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertJsonStringEqualsJsonFile(__DIR__ . '/fixtures/Search.2.0.khmer.json', json_encode($json), "Search for 'khmer' gives same results as Search.2.0.khmer.json");
@@ -53,7 +53,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testPhraseSearchResult()
     {
-      $json = $this->s->GetSearchMatches(null, 'khmer angkor', 1);
+      $json = $this->s->GetSearchMatches(null, 'khmer angkor', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertJsonStringEqualsJsonFile(__DIR__ . '/fixtures/Search.2.0.khmer-angkor.json', json_encode($json), "Search for 'khmer angkor' gives same results as Search.2.0.khmer-angkor.json");
@@ -61,7 +61,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testUnicodeSearchResult()
     {
-      $json = $this->s->GetSearchMatches(null, 'ት', 1);
+      $json = $this->s->GetSearchMatches(null, 'ት', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertJsonStringEqualsJsonFile(__DIR__ . '/fixtures/Search.2.0.ethiopic.json', json_encode($json), "Search for 'ት' gives same results as Search.2.0.ethiopic.json");
@@ -69,7 +69,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testKeyboardIdSearchResult()
     {
-      $json = $this->s->GetSearchMatches(null, 'khmer_', 1);
+      $json = $this->s->GetSearchMatches(null, 'khmer_', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
@@ -77,7 +77,7 @@ namespace Keyman\Site\com\keyman\api\tests {
     }
 
     public function testDinkaSearchResult() {
-      $json = $this->s->GetSearchMatches(null, 'Thuɔŋjäŋ', 1);
+      $json = $this->s->GetSearchMatches(null, 'Thuɔŋjäŋ', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(3, $json->context->totalRows);
@@ -90,7 +90,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByKeyboard()
     {
-      $json = $this->s->GetSearchMatches(null, 'k:khmer', 1);
+      $json = $this->s->GetSearchMatches(null, 'k:khmer', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertJsonStringEqualsJsonFile(__DIR__ . '/fixtures/Search.2.0.khmer-keyboards.json', json_encode($json), "Search for 'k:khmer' gives same results as Search.2.0.khmer-keyboards.json");
@@ -98,14 +98,14 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByKeyboardId()
     {
-      $json = $this->s->GetSearchMatches(null, 'id:basic_kbdkhmr', 1);
+      $json = $this->s->GetSearchMatches(null, 'id:basic_kbdkhmr', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
       $this->assertEquals('basic_kbdkhmr', $json->keyboards[0]->id);
       $this->assertEquals('keyboard_id', $json->keyboards[0]->match->type);
 
-      $json = $this->s->GetSearchMatches(null, 'k:id:basic_kbdkhmr', 1);
+      $json = $this->s->GetSearchMatches(null, 'k:id:basic_kbdkhmr', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
@@ -115,14 +115,14 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByLegacyKeyboardId()
     {
-      $json = $this->s->GetSearchMatches(null, 'legacy:681', 1);
+      $json = $this->s->GetSearchMatches(null, 'legacy:681', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
       $this->assertEquals('acoli', $json->keyboards[0]->id);
       $this->assertEquals('legacy_keyboard_id', $json->keyboards[0]->match->type);
 
-      $json = $this->s->GetSearchMatches(null, 'k:legacy:681', 1);
+      $json = $this->s->GetSearchMatches(null, 'k:legacy:681', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
@@ -132,14 +132,14 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByLanguageBcp47Tag()
     {
-      $json = $this->s->GetSearchMatches(null, 'l:id:ach', 1);
+      $json = $this->s->GetSearchMatches(null, 'l:id:ach', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
       $this->assertEquals('acoli', $json->keyboards[0]->id);
       $this->assertEquals('language_bcp47_tag', $json->keyboards[0]->match->type);
 
-      $json = $this->s->GetSearchMatches(null, 'l:id:km-Khmr-KH', 1);
+      $json = $this->s->GetSearchMatches(null, 'l:id:km-Khmr-KH', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(6, $json->context->totalRows);
@@ -156,7 +156,7 @@ namespace Keyman\Site\com\keyman\api\tests {
     public function testSearchResultForKeyboardsBcp47Tag()
     {
       // We should return the tag from the keyboard in the match->tag field, not the normalised tag
-      $json = $this->s->GetSearchMatches(null, 'l:id:str-latn', 1);
+      $json = $this->s->GetSearchMatches(null, 'l:id:str-latn', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(3, $json->context->totalRows);
@@ -164,7 +164,7 @@ namespace Keyman\Site\com\keyman\api\tests {
       $this->assertEquals('language_bcp47_tag', $json->keyboards[0]->match->type);
       $this->assertEquals('str-latn', $json->keyboards[0]->match->tag);
 
-      $json = $this->s->GetSearchMatches(null, 'sencoten', 1);
+      $json = $this->s->GetSearchMatches(null, 'sencoten', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(3, $json->context->totalRows);
@@ -175,7 +175,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByLanguageName()
     {
-      $json = $this->s->GetSearchMatches(null, 'l:Blang', 1);
+      $json = $this->s->GetSearchMatches(null, 'l:Blang', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
@@ -184,7 +184,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByCountryIso3166Code()
     {
-      $json = $this->s->GetSearchMatches(null, 'c:id:nz', 1);
+      $json = $this->s->GetSearchMatches(null, 'c:id:nz', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(5, $json->context->totalRows);
@@ -194,7 +194,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByCountryName()
     {
-      $json = $this->s->GetSearchMatches(null, 'c:Tanzania', 1);
+      $json = $this->s->GetSearchMatches(null, 'c:Tanzania', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(6, $json->context->totalRows);
@@ -203,7 +203,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByScriptIso15924Code()
     {
-      $json = $this->s->GetSearchMatches(null, 's:id:bali', 1);
+      $json = $this->s->GetSearchMatches(null, 's:id:bali', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
@@ -213,7 +213,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByScriptName()
     {
-      $json = $this->s->GetSearchMatches(null, 's:Ethiopic', 1);
+      $json = $this->s->GetSearchMatches(null, 's:Ethiopic', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(42, $json->context->totalRows);
@@ -226,7 +226,7 @@ namespace Keyman\Site\com\keyman\api\tests {
      */
     public function testSearchByCustomLanguageName()
     {
-      $json = $this->s->GetSearchMatches(null, 'Central Bontok', 1);
+      $json = $this->s->GetSearchMatches(null, 'Central Bontok', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
@@ -241,7 +241,7 @@ namespace Keyman\Site\com\keyman\api\tests {
      */
     public function testSearchByCustomLanguageTag()
     {
-      $json = $this->s->GetSearchMatches(null, 'l:id:khw-latn', 1);
+      $json = $this->s->GetSearchMatches(null, 'l:id:khw-latn', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(1, $json->context->totalRows);
@@ -256,7 +256,7 @@ namespace Keyman\Site\com\keyman\api\tests {
      */
     public function testSearchByLanguageFindsCustomTag()
     {
-      $json = $this->s->GetSearchMatches(null, 'l:Khowar', 1);
+      $json = $this->s->GetSearchMatches(null, 'l:Khowar', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(4, $json->context->totalRows);
@@ -274,7 +274,7 @@ namespace Keyman\Site\com\keyman\api\tests {
      */
     public function testSearchByCustomLanguageTag2()
     {
-      $json = $this->s->GetSearchMatches(null, 'l:id:pi', 1);
+      $json = $this->s->GetSearchMatches(null, 'l:id:pi', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(2, $json->context->totalRows);
@@ -284,7 +284,7 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByPopularity()
     {
-      $json = $this->s->GetSearchMatches(null, 'p:*', 1);
+      $json = $this->s->GetSearchMatches(null, 'p:*', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
       $this->assertEquals(659, $json->context->totalRows);

--- a/tests/Search20Test.php
+++ b/tests/Search20Test.php
@@ -290,5 +290,30 @@ namespace Keyman\Site\com\keyman\api\tests {
       $this->assertEquals(659, $json->context->totalRows);
       $this->assertEquals('gff_amharic', $json->keyboards[0]->id);
     }
+
+    public function testSearchExcludeObsoleteKeyboards() {
+      $json = $this->s->GetSearchMatches(null, 'khmer', 0, 1);
+      $json = json_decode(json_encode($json));
+      $this->schema->in($json);
+      $this->assertEquals(5, $json->context->totalRows);
+      $this->assertEquals('khmer_angkor', $json->keyboards[0]->id);
+      $this->assertEquals('sil_khmer', $json->keyboards[1]->id);
+      $this->assertEquals('basic_kbdkni', $json->keyboards[2]->id);
+      $this->assertEquals('basic_kbdkhmr', $json->keyboards[3]->id);
+      $this->assertEquals('krung', $json->keyboards[4]->id);
+
+      $json = $this->s->GetSearchMatches(null, 'khmer', 1, 1);
+      $json = json_decode(json_encode($json));
+      $this->schema->in($json);
+      $this->assertEquals(7, $json->context->totalRows);
+      $this->assertEquals('khmer_angkor', $json->keyboards[0]->id);
+      $this->assertEquals('sil_khmer', $json->keyboards[1]->id);
+      $this->assertEquals('basic_kbdkni', $json->keyboards[2]->id);
+      $this->assertEquals('basic_kbdkhmr', $json->keyboards[3]->id);
+      $this->assertEquals('krung', $json->keyboards[4]->id);
+      // Following two are obsolete
+      $this->assertEquals('khmer10', $json->keyboards[5]->id);
+      $this->assertEquals('kbdkhmr', $json->keyboards[6]->id);
+    }
   }
 }

--- a/tools/db/build/build_keyboards_script.inc.php
+++ b/tools/db/build/build_keyboards_script.inc.php
@@ -145,6 +145,7 @@
           platform_linux,
 
           deprecated,
+          obsolete,
 
           keyboard_info
         ) VALUES
@@ -216,6 +217,7 @@ $insert
           {$this->sqlb(null, $platform_web)},
           {$this->sqlb(null, $platform_linux)},
 
+          0,
           0,
 
           {$this->sqlv($keyboard, 'json')});

--- a/tools/db/build/search-prepare-data.sql
+++ b/tools/db/build/search-prepare-data.sql
@@ -32,6 +32,14 @@ update t_model
   where exists (select * from t_model_related mr where mr.related_model_id = t_model.model_id);
 
 --
+-- Any keyboard that has been replaced by another one, or is not Unicode, is marked as obsolete
+--
+
+update t_keyboard
+  set obsolete = 1
+  where deprecated = 1 or is_unicode = 0
+
+--
 -- Canonicalize bcp47 codes into langtags entries
 --
 -- Fixup those that are missing from t_langtags, first

--- a/tools/db/build/search.sql
+++ b/tools/db/build/search.sql
@@ -109,6 +109,7 @@ CREATE TABLE t_keyboard (
   platform_linux tinyint,
 
   deprecated bit,
+  obsolete bit,
 
   keyboard_info nvarchar(max)
 );

--- a/tools/db/build/sp_keyboard_search_by_country.sql
+++ b/tools/db/build/sp_keyboard_search_by_country.sql
@@ -8,6 +8,7 @@ GO
 CREATE PROCEDURE sp_keyboard_search_by_country
   @prmSearchText nvarchar(250),
   @prmPlatform nvarchar(32),
+  @prmObsolete bit,
   @prmPageNumber int,
   @prmPageSize int
 AS
@@ -40,7 +41,7 @@ BEGIN
 
   SET NOCOUNT OFF;
 
-  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @tt_keyboard)
-  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @tt_keyboard)
+  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
+  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
 END
 GO

--- a/tools/db/build/sp_keyboard_search_by_country_iso3166_code.sql
+++ b/tools/db/build/sp_keyboard_search_by_country_iso3166_code.sql
@@ -8,6 +8,7 @@ GO
 CREATE PROCEDURE sp_keyboard_search_by_country_iso3166_code
   @prmSearchText nvarchar(250),
   @prmPlatform nvarchar(32),
+  @prmObsolete bit,
   @prmPageNumber int,
   @prmPageSize int
 AS
@@ -38,7 +39,7 @@ BEGIN
 
   SET NOCOUNT OFF;
 
-  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @tt_keyboard)
-  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @tt_keyboard)
+  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
+  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
 END
 GO

--- a/tools/db/build/sp_keyboard_search_by_id.sql
+++ b/tools/db/build/sp_keyboard_search_by_id.sql
@@ -8,7 +8,8 @@ DROP PROCEDURE IF EXISTS sp_keyboard_search_by_id
 GO
 
 CREATE PROCEDURE sp_keyboard_search_by_id (
-  @prmSearchPlain NVARCHAR(250)
+  @prmSearchPlain NVARCHAR(250),
+  @prmObsolete BIT
 ) AS
 BEGIN
   SELECT
@@ -45,15 +46,17 @@ BEGIN
     k.platform_web,
     k.platform_linux,
     k.deprecated,
+    k.obsolete,
     k.keyboard_info
 
   FROM
     t_keyboard k left join
     t_keyboard_downloads kd on k.keyboard_id = kd.keyboard_id
   WHERE
-    k.keyboard_id LIKE @prmSearchPlain+'%'
+    k.keyboard_id LIKE @prmSearchPlain+'%' AND
+    (k.obsolete = 0 or @prmObsolete = 1)
   ORDER BY
-    k.deprecated ASC, -- deprecated keyboards always last
+    k.obsolete ASC, -- deprecated keyboards always last
     5 DESC, -- order by final_weight descending
     k.name ASC -- fallback on identical weight
 END

--- a/tools/db/build/sp_keyboard_search_by_keyboard.sql
+++ b/tools/db/build/sp_keyboard_search_by_keyboard.sql
@@ -5,6 +5,7 @@ CREATE PROCEDURE sp_keyboard_search_by_keyboard
   @prmSearchText nvarchar(250),
   @prmIDSearchText nvarchar(250), -- should be ascii (ideally, id only /[a-z][a-z0-9_]*/)
   @prmPlatform nvarchar(32),
+  @prmObsolete bit,
   @prmPageNumber int,
   @prmPageSize int
 AS
@@ -35,7 +36,7 @@ BEGIN
 
   SET NOCOUNT OFF;
 
-  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @tt_keyboard)
-  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @tt_keyboard)
+  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
+  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
 END
 GO

--- a/tools/db/build/sp_keyboard_search_by_language.sql
+++ b/tools/db/build/sp_keyboard_search_by_language.sql
@@ -4,6 +4,7 @@ GO
 CREATE PROCEDURE sp_keyboard_search_by_language
   @prmSearchText nvarchar(250),
   @prmPlatform nvarchar(32),
+  @prmObsolete bit,
   @prmPageNumber int,
   @prmPageSize int
 AS
@@ -36,7 +37,7 @@ BEGIN
 
   SET NOCOUNT OFF;
 
-  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @tt_keyboard)
-  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @tt_keyboard)
+  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
+  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
 END
 GO

--- a/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
+++ b/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
@@ -11,6 +11,7 @@ GO
 CREATE PROCEDURE sp_keyboard_search_by_language_bcp47_tag (
   @prmTag NVARCHAR(250),
   @prmPlatform NVARCHAR(32),
+  @prmObsolete BIT,
   @prmPageNumber INT,
   @prmPageSize INT
 ) AS
@@ -68,6 +69,7 @@ BEGIN
     k.platform_web,
     k.platform_linux,
     k.deprecated,
+    k.obsolete,
     k.keyboard_info
 
   FROM
@@ -75,6 +77,7 @@ BEGIN
     t_keyboard_downloads kd on k.keyboard_id = kd.keyboard_id
   WHERE
     EXISTS (SELECT * FROM t_keyboard_langtag kl WHERE kl.keyboard_id = k.keyboard_id AND kl.tag = @varTag) AND
+    (k.obsolete = 0 or @prmObsolete = 1) AND
     ((@prmPlatform is null) or
     (@prmPlatform = 'android' and k.platform_android > 0) or
     (@prmPlatform = 'ios'     and k.platform_ios > 0) or
@@ -83,8 +86,7 @@ BEGIN
     (@prmPlatform = 'web'     and k.platform_web > 0) or
     (@prmPlatform = 'windows' and k.platform_windows > 0))
   ORDER BY
-    k.deprecated ASC,
-    k.is_unicode DESC,
+    k.obsolete ASC,
     5 DESC, --final_weight
     k.name
   offset

--- a/tools/db/build/sp_keyboard_search_by_legacy_id.sql
+++ b/tools/db/build/sp_keyboard_search_by_legacy_id.sql
@@ -44,10 +44,11 @@ CREATE PROCEDURE sp_keyboard_search_by_legacy_id (
     k.platform_web,
     k.platform_linux,
     k.deprecated,
+    k.obsolete,
     k.keyboard_info
 
   FROM
     t_keyboard k left join
     t_keyboard_downloads kd on k.keyboard_id = kd.keyboard_id
   WHERE
-    k.legacy_id  = @prmLegacyID
+    k.legacy_id = @prmLegacyID

--- a/tools/db/build/sp_keyboard_search_by_popularity.sql
+++ b/tools/db/build/sp_keyboard_search_by_popularity.sql
@@ -35,7 +35,7 @@ BEGIN
 
   SET NOCOUNT OFF;
 
-  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @tt_keyboard)
-  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @tt_keyboard)
+  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, 0, @tt_keyboard)
+  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, 0, @tt_keyboard)
 END
 GO

--- a/tools/db/build/sp_keyboard_search_by_script.sql
+++ b/tools/db/build/sp_keyboard_search_by_script.sql
@@ -8,6 +8,7 @@ GO
 CREATE PROCEDURE sp_keyboard_search_by_script
   @prmSearchText nvarchar(250),
   @prmPlatform nvarchar(32),
+  @prmObsolete bit,
   @prmPageNumber int,
   @prmPageSize int
 AS
@@ -34,7 +35,7 @@ BEGIN
 
   SET NOCOUNT OFF;
 
-  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @tt_keyboard)
-  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @tt_keyboard)
+  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
+  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
 END
 GO

--- a/tools/db/build/sp_keyboard_search_by_script_iso15924_code.sql
+++ b/tools/db/build/sp_keyboard_search_by_script_iso15924_code.sql
@@ -8,6 +8,7 @@ GO
 CREATE PROCEDURE sp_keyboard_search_by_script_iso15924_code
   @prmSearchText nvarchar(250),
   @prmPlatform nvarchar(32),
+  @prmObsolete bit,
   @prmPageNumber int,
   @prmPageSize int
 AS
@@ -37,7 +38,7 @@ BEGIN
 
   SET NOCOUNT OFF;
 
-  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @tt_keyboard)
-  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @tt_keyboard)
+  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
+  select * from f_keyboard_search_results(@prmPageSize, @prmPageNumber, @prmObsolete, @tt_keyboard)
 END
 GO


### PR DESCRIPTION
The search now skips deprecated and non-Unicode keyboards by default. Passing the parameter obsolete=1 will list all keyboards including obsolete ones. Obsolete keyboards will always be listed last.

Front end on keyman.com keymanapp/keyman.com#147

Relates to #87.