### PR TITLE
fix: obsolete keyboards in stats

### DIFF
--- a/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
+++ b/tools/db/build/sp_keyboard_search_by_language_bcp47_tag.sql
@@ -27,6 +27,7 @@ BEGIN
     t_keyboard k
   WHERE
     EXISTS (SELECT * FROM t_keyboard_langtag kl WHERE kl.keyboard_id = k.keyboard_id AND kl.tag = @varTag) AND
+    (k.obsolete = 0 or @prmObsolete = 1) AND
     ((@prmPlatform is null) or
     (@prmPlatform = 'android' and k.platform_android > 0) or
     (@prmPlatform = 'ios'     and k.platform_ios > 0) or


### PR DESCRIPTION
Fixes #112. When searching by langid, obsolete keyboards were included in statistics even though they were not listed.