### PR TITLE
fix: async database build

### DIFF
--- a/App_Data/jobs/continuous/database_build/README.md
+++ b/App_Data/jobs/continuous/database_build/README.md
@@ -1,0 +1,15 @@
+# Continuous job for rebuilding database
+
+This script is a Kudu webjob. See https://github.com/projectkudu/kudu/wiki/WebJobs for details
+
+The script watches for .data/MUST_REBUILD to be created. If it is present, then creates
+.data/BUILDING, deletes .data/MUST_REBUILD, and starts a database rebuild. When it is
+finished, it deletes .data/BUILDING, and exits the script. Kudu will restart the script
+within one minute of it exiting.
+
+Logs are visible in Kudu interface. If the database is already building, this will
+trigger a rebuild a few seconds after the current rebuild finishes. There is a
+theoretical race if two separate rebuild events are received within a fraction of
+a second of each other -- but the likelihood of this causing data mismatch is near
+zero, as by the time the file downloads start, the source data will already be
+ready.

--- a/App_Data/jobs/continuous/database_build/run.bat
+++ b/App_Data/jobs/continuous/database_build/run.bat
@@ -1,0 +1,19 @@
+@echo off
+rem This script is a Kudu webjob. See README.md
+
+:run
+if exist \home\site\wwwroot\.data\MUST_REBUILD if not exist \home\site\wwwroot\.data\BUILDING goto rebuild
+sleep 5 > nul
+goto run
+
+:rebuild
+echo Triggering database rebuild
+echo Building > \home\site\wwwroot\.data\BUILDING
+del \home\site\wwwroot\.data\MUST_REBUILD
+cd \home\site\wwwroot
+call composer run-script --timeout=0 build
+del \home\site\wwwroot\.data\BUILDING
+
+rem We'll exit the script (Kudu will restart it) so we get logs for subsequent runs in Kudu
+rem (only first 100 lines by default go to the kudu logs). This will cause a 60 second delay,
+rem which is probably not a bad thing in any case ;-)

--- a/App_Data/jobs/continuous/database_build/settings.job
+++ b/App_Data/jobs/continuous/database_build/settings.job
@@ -1,0 +1,3 @@
+{
+  "is_singleton": true
+}

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,14 @@
         "phpunit/phpunit": "^9"
     },
     "scripts": {
-      "test": "vendor\\bin\\phpunit --testdox",
-      "build": "php tools\\db\\build\\build_cli.php",
+      "test": [
+        "Composer\\Config::disableProcessTimeout",
+        "vendor\\bin\\phpunit --testdox"
+      ],
+      "build": [
+        "Composer\\Config::disableProcessTimeout",
+        "php tools\\db\\build\\build_cli.php"
+      ],
       "lint": "find . -name '*.php' | grep -v '/vendor/' | xargs -n 1 php -l"
     }
 }

--- a/script/hooks/keyboards-build-success.php
+++ b/script/hooks/keyboards-build-success.php
@@ -28,36 +28,14 @@
     fail('Invalid token');
   }
 
-  $log = "Triggered database build for keymanapp/keyboards and keymanapp/lexical-models\n".
-         "=============================================================================\n\n";
+  $log = "Triggered database build for keymanapp/keyboards and keymanapp/lexical-models";
 
-  function build_log($message) {
-    global $log;
-    $log .= $message . "\n";
+  // This triggers the continuous webjob in App_Data/WebJobs/continuous/database_build
+  file_put_contents('../../.data/MUST_REBUILD', "must rebuild");
+
+  if($format === 'application/json') {
+    echo json_encode(array("log" => $log));
+  } else {
+    echo $log;
   }
-
-  require_once('../../tools/db/build/build.inc.php');
-  require_once('../../tools/db/build/cjk/build.inc.php');
-  require_once('../../tools/db/build/datasources.inc.php');
-
-  function Build() {
-    $DBDataSources = new DBDataSources();
-    $dci = new DatabaseConnectionInfo();
-    $schema = $dci->getInactiveSchema();
-
-    $B = new BuildCJKTableClass();
-    $B->BuildDatabase($DBDataSources, $schema, true);
-    $B->BuildCJKTables($DBDataSources, $schema, true);
-
-    $dci->setActiveSchema($schema);
-
-    global $format, $log;
-    if($format === 'application/json') {
-      echo json_encode(array("log" => $log));
-    } else {
-      echo $log;
-    }
-  }
-
-  Build();
 ?>

--- a/tools/db/build/build_cli.php
+++ b/tools/db/build/build_cli.php
@@ -4,6 +4,8 @@
   require_once(__DIR__ . '/build.inc.php');
   require_once(__DIR__ . '/cjk/build.inc.php');
 
+  set_time_limit(0); // disable script timeout
+
   // CLI version of fail
   function fail($s) {
     echo $s;


### PR DESCRIPTION
This uses Kudu continuous webjob to trigger a database build whenever a file .data/MUST_REBUILD is created. This pattern is used from the webhook and also from git deploys (see the PostDeploymentActions for the staging api site).

In the future, we may move to using a triggered webjob, and fire the trigger when needed, but for now this model is simpler.

Fixes #114.

I decided to do this one earlier because of the broken PR https://github.com/keymanapp/keyman.com/pull/194, which was caused by an out-of-date database. Once this merges, I'll re-enable the build configuration step to notify api.keyman-staging.com for the keyboards / models builds and the staging site should then stay in sync with the live site.