### PR TITLE
fix: update and exception endpoints regexes

### DIFF
--- a/web.config
+++ b/web.config
@@ -154,18 +154,18 @@
 
         <rule name="desktop/10.0-13.0/update" stopProcessing="true">
           <match url="^desktop/(10|11|12|13)\.[0-9]/update(.*)" />
-          <action type="Rewrite" url="/script/desktop/10.0/update/index.php{R:1}" />
+          <action type="Rewrite" url="/script/desktop/10.0/update/index.php{R:2}" appendQueryString="true" />
         </rule>
 
         <rule name="desktop/10.0/exception" stopProcessing="true">
           <!-- Note: this endpoint is also used by developer -->
           <match url="^desktop/[1-9][0-9]\.[0-9]/exception(.*)" />
-          <action type="Rewrite" url="/script/desktop/10.0/exception/index.php{R:1}" />
+          <action type="Rewrite" url="/script/desktop/10.0/exception/index.php{R:2}" appendQueryString="true" />
         </rule>
 
         <rule name="desktop/10.0/isonline" stopProcessing="true">
           <match url="^desktop/[1-9][0-9]\.[0-9]/isonline(/?)$" />
-          <action type="Rewrite" url="/script/desktop/10.0/isonline/index.php" />
+          <action type="Rewrite" url="/script/desktop/10.0/isonline/index.php" appendQueryString="true" />
         </rule>
 
         <rule name="desktop/10.0/submitdiag" stopProcessing="true">


### PR DESCRIPTION
The regexes for version 10-13 for these endpoints was incorrect after tightening the match to only those versions. Note `{R:2}` is likely never needed in any case...