### PR TITLE
feat: major version upgrades (Windows)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
   "json.schemas": [
     {"fileMatch": ["langtags*.json"], "url": "./tools/db/build/langtags.schema.json" }
-    ]
+    ],
+    "workbench.colorCustomizations": {
+      "activityBar.background": "#143040",
+      "titleBar.activeBackground": "#1C445A",
+      "titleBar.activeForeground": "#F6FAFC"
+    }
   }

--- a/schemas/windows-update/14.0/windows-update.json
+++ b/schemas/windows-update/14.0/windows-update.json
@@ -14,19 +14,25 @@
       "additionalProperties": true,
       "properties": {
         "msi": {
-          "$ref": "#/definitions/file"
+          "$ref": "#/definitions/optional-file"
         },
         "setup": {
-          "$ref": "#/definitions/file"
+          "$ref": "#/definitions/optional-file"
         },
         "bundle": {
-          "$ref": "#/definitions/file"
+          "$ref": "#/definitions/optional-file"
         },
         "keyboards": {
           "$ref": "#/definitions/keyboards"
         }
       }
     },
+
+    "optional-file":         {  "anyOf": [
+      { "$ref": "#/definitions/file" },
+      { "type": "boolean" }
+    ]
+  },
 
     "file": {
       "type": "object",

--- a/schemas/windows-update/14.0/windows-update.json
+++ b/schemas/windows-update/14.0/windows-update.json
@@ -5,12 +5,7 @@
   "definitions": {
     "windows-update": {
       "type": "object",
-      "required": [
-        "msi",
-        "setup",
-        "bundle",
-        "keyboards"
-      ],
+      "required": ["msi", "setup", "bundle", "keyboards"],
       "additionalProperties": true,
       "properties": {
         "msi": {
@@ -28,11 +23,9 @@
       }
     },
 
-    "optional-file":         {  "anyOf": [
-      { "$ref": "#/definitions/file" },
-      { "type": "boolean" }
-    ]
-  },
+    "optional-file": {
+      "anyOf": [{ "$ref": "#/definitions/file" }, { "type": "boolean" }]
+    },
 
     "file": {
       "type": "object",

--- a/script/desktop/10.0/update/index.php
+++ b/script/desktop/10.0/update/index.php
@@ -2,6 +2,6 @@
   require_once('../../../../tools/base.inc.php');
   require_once('../../../../tools/onlineupdate.php');
 
-  $u = new OnlineUpdate('windows', '/^keymandesktop.+\.exe$/');
+  $u = new OnlineUpdate('windows', '/^keyman(desktop)?.+\.exe$/');
   $u->execute();
 ?>

--- a/script/windows/14.0/update/WindowsUpdateCheck.php
+++ b/script/windows/14.0/update/WindowsUpdateCheck.php
@@ -86,7 +86,9 @@
         // This is currently tied to Windows -- for other platforms we need to change this
         if(preg_match($regex, $file)) {
 
-          if(!$this->isManual && !$this->IsSameMajorVersion($InstalledVersion, $tierdata->version)) {
+          if(!$this->isManual &&
+              $this->tier == 'stable' &&
+              !$this->IsSameMajorVersion($InstalledVersion, $tierdata->version)) {
             // We're going to stagger upgrades by the minute of the hour for the check, to
             // ensure we don't have everyone major-update at once and potentially cause us
             // grief. This will mean that we need additional PRs to update this value; that

--- a/script/windows/14.0/update/WindowsUpdateCheck.php
+++ b/script/windows/14.0/update/WindowsUpdateCheck.php
@@ -87,7 +87,7 @@
         if(preg_match($regex, $file)) {
 
           if(!$this->isManual &&
-              $this->tier == 'stable' &&
+              $tier == 'stable' &&
               !$this->IsSameMajorVersion($InstalledVersion, $tierdata->version)) {
             // We're going to stagger upgrades by the minute of the hour for the check, to
             // ensure we don't have everyone major-update at once and potentially cause us

--- a/script/windows/14.0/update/WindowsUpdateCheck.php
+++ b/script/windows/14.0/update/WindowsUpdateCheck.php
@@ -81,6 +81,7 @@
     private function CheckVersionResponse($tier, $tiers, $InstalledVersion, $regex) {
       if(!isset($tiers[$tier])) return FALSE;
       $tierdata = $tiers[$tier];
+      if(is_array($tierdata->files)) return FALSE;
 
       $files = get_object_vars($tierdata->files);
       foreach($files as $file => $filedata) {

--- a/script/windows/14.0/update/index.php
+++ b/script/windows/14.0/update/index.php
@@ -9,12 +9,13 @@
 
   if(!isset($_REQUEST['version'])) {
     /* Invalid update check */
-    fail('Invalid Parameters - expected Version parameter', 401);
+    fail('Invalid Parameters - expected version parameter', 401);
   }
 
   $tier = isset($_REQUEST['tier']) ? $_REQUEST['tier'] : 'stable';
 
   $isUpdate = empty($_REQUEST['update']) ? 0 : 1;
+  $isManual = empty($_REQUEST['manual']) ? 0 : 1;
 
   $packages = [];
   foreach ($_REQUEST as $id => $version) {
@@ -31,4 +32,4 @@
   $mssql = Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
 
   $u = new Keyman\Site\com\keyman\api\WindowsUpdateCheck();
-  echo $u->execute($mssql, $tier, $_REQUEST['version'], $packages, $isUpdate);
+  echo $u->execute($mssql, $tier, $_REQUEST['version'], $packages, $isUpdate, $isManual);

--- a/tests/ReleaseScheduleTest.php
+++ b/tests/ReleaseScheduleTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Keyman\Site\com\keyman\api\tests {
+  require_once(__DIR__ . '/../tools/base.inc.php');
+  require_once(__DIR__ . '/../script/package-version/package-version.inc.php');
+  require_once(__DIR__ . '/TestUtils.inc.php');
+  require_once(__DIR__ . '/TestDBBuild.inc.php');
+
+    use Keyman\Site\com\keyman\api\ReleaseSchedule;
+    use PHPUnit\Framework\TestCase;
+
+  final class ReleaseScheduleTest extends TestCase
+  {
+    public function testReleaseScheduleIsValid(): void
+    {
+      // mktime params: hour minute second month day year (seriously... can you imagine a worse order oh and year can be 2 digits)
+      $this->assertFalse(ReleaseSchedule::DoesRequestMeetSchedule('2020-01-01', mktime(0, 0, 0, 12, 30, 2019)), 'current time before release date should not meet schedule');
+
+      $this->assertTrue(ReleaseSchedule::DoesRequestMeetSchedule('2020-01-01', mktime(0, 0, 0, 1, 1, 2020)), 'current time same as release date should meet schedule for 0 minutes');
+      $this->assertFalse(ReleaseSchedule::DoesRequestMeetSchedule('2020-01-01', mktime(0, 15, 0, 1, 1, 2020)), 'current time same as release date should not meet schedule for 15 minutes');
+
+      $this->assertTrue(ReleaseSchedule::DoesRequestMeetSchedule('2020-01-01', mktime(0, 0, 0, 1, 6, 2020)), '5 days after release should meet schedule for 0 minutes');
+      $this->assertFalse(ReleaseSchedule::DoesRequestMeetSchedule('2020-01-01', mktime(0, 7, 0, 1, 6, 2020)), '5 days after release should not meet schedule for 7 minutes');
+
+      $this->assertTrue(ReleaseSchedule::DoesRequestMeetSchedule('2020-01-01', mktime(0, 13, 0, 1, 16, 2020)), '15 days after release should meet schedule for 13 minutes');
+      $this->assertFalse(ReleaseSchedule::DoesRequestMeetSchedule('2020-01-01', mktime(0, 59, 0, 1, 16, 2020)), '15 days after release should meet schedule for 13 minutes');
+
+      $this->assertTrue(ReleaseSchedule::DoesRequestMeetSchedule('2020-01-01', mktime(0, 59, 0, 1, 23, 2020)), '22 days after release should meet schedule for 59 minutes');
+    }
+  }
+}

--- a/tests/WindowsUpdateCheckTest.php
+++ b/tests/WindowsUpdateCheckTest.php
@@ -20,10 +20,14 @@ final class WindowsUpdateCheckTest extends ApiTestCase
     $this->schema = TestUtils::LoadJSONSchema(self::SchemaFilename);
   }
 
-  public function testSimpleResultValidatesAgainstSchema(): void
+  // Note, in these tests, we send earlier version numbers in. This is fine as we
+  // don't ever actually restrict this API to 14.0 or later versions, and we do so
+  // in order to exercise major version upgrade scenarios.
+
+  private function getJsonString($tier, $appVersion, $packages, $isUpdate, $isManual, $currentTime = null)
   {
     $u = new \Keyman\Site\com\keyman\api\WindowsUpdateCheck();
-    $json = $u->execute($this->mssql, 'alpha', '14.0.100', ['khmer_angkor'=>'1.0.2', 'foo'=>'0.1'], 0, 1);
+    $json = $u->execute($this->mssql, $tier, $appVersion, $packages, $isUpdate, $isManual, $currentTime);
     $this->assertNotEmpty($json);
     $data = json_decode($json);
     $this->assertNotNull($data);
@@ -31,7 +35,76 @@ final class WindowsUpdateCheckTest extends ApiTestCase
     // This will throw an exception if it does not pass
     $this->schema->in($data);
 
-    // TODO: add some more realism!
+    return $json;
+  }
+
+  private function getJson($tier, $appVersion, $packages, $isUpdate, $isManual, $currentTime = null)
+  {
+    return json_decode($this->getJsonString($tier, $appVersion, $packages, $isUpdate, $isManual, $currentTime));
+  }
+
+  public function testSimpleResultValidatesAgainstSchema(): void
+  {
+    $json = $this->getJsonString('alpha', '14.0.100', ['khmer_angkor'=>'1.0.2', 'foo'=>'0.1'], 0, 1);
     $this->assertJsonStringEqualsJsonFile(__DIR__ . '/fixtures/WindowsUpdateCheck.14.0.json', $json);
+  }
+
+  public function testAlphaStaysInAlpha(): void
+  {
+    $json = $this->getJson('alpha', '13.0.100', [], 0, 1);
+    $this->assertEquals('alpha', $json->bundle->stability);
+    $this->assertEquals('14.0.102.0', $json->bundle->version);
+  }
+
+  public function testBetaUpgradesToStable(): void
+  {
+    $json = $this->getJson('beta', '13.0.77', [], 0, 1);
+    $this->assertEquals('stable', $json->bundle->stability);
+    $this->assertEquals('13.0.109.0', $json->bundle->version);
+  }
+
+  public function testStableStaysInStable(): void
+  {
+    $json = $this->getJson('stable', '12.0.10', [], 0, 1);
+    $this->assertEquals('stable', $json->bundle->stability);
+    $this->assertEquals('13.0.109.0', $json->bundle->version);
+  }
+
+  public function testStableGetsDelayedRollout(): void
+  {
+    // test 1 day after release
+    // from fixture, 13.0.109.0 was released 2020-06-05
+    // rollout schedule is defined in ReleaseSchedule and is based on minute of the hour
+    // mktime is h:m:s, m/d/y (yuk!)
+
+    // out-of-schedule
+    $json = $this->getJson('stable', '12.0.10', [], 0, 0, mktime(0, 20, 0, 6, 6, 2020));
+    $this->assertFalse($json->bundle, 'should not be offered release');
+
+    // in-schedule
+    $json = $this->getJson('stable', '12.0.10', [], 0, 0, mktime(0, 1, 0, 6, 6, 2020));
+    $this->assertEquals('13.0.109.0', $json->bundle->version, 'should be offered release');
+
+    // minor update, out-of-schedule
+    $json = $this->getJson('stable', '13.0.107.0', [], 0, 0, mktime(0, 20, 0, 6, 6, 2020));
+    $this->assertEquals('13.0.109.0', $json->bundle->version, 'should be offered release');
+
+    // test 30 days after release
+
+    // in-schedule, 59 minutes after hour
+    $json = $this->getJson('stable', '12.0.10', [], 0, 0, mktime(0, 59, 0, 7, 4, 2020));
+    $this->assertEquals('13.0.109.0', $json->bundle->version, 'should be offered release');
+
+    // in-schedule, 1 minute after hour
+    $json = $this->getJson('stable', '12.0.10', [], 0, 0, mktime(0, 1, 0, 7, 4, 2020));
+    $this->assertEquals('13.0.109.0', $json->bundle->version, 'should be offered release');
+
+    // minor update, in-schedule
+    $json = $this->getJson('stable', '13.0.107.0', [], 0, 0, mktime(0, 59, 0, 7, 4, 2020));
+    $this->assertEquals('13.0.109.0', $json->bundle->version, 'minor update should be offered release');
+
+    // out-of-schedule, major update, test manual check
+    $json = $this->getJson('stable', '12.0.10', [], 0, 1, mktime(0, 20, 0, 6, 6, 2020));
+    $this->assertEquals('13.0.109.0', $json->bundle->version, 'major update manual check should be offered release');
   }
 }

--- a/tests/WindowsUpdateCheckTest.php
+++ b/tests/WindowsUpdateCheckTest.php
@@ -23,7 +23,7 @@ final class WindowsUpdateCheckTest extends ApiTestCase
   public function testSimpleResultValidatesAgainstSchema(): void
   {
     $u = new \Keyman\Site\com\keyman\api\WindowsUpdateCheck();
-    $json = $u->execute($this->mssql, 'alpha', '14.0.100', ['khmer_angkor'=>'1.0.2', 'foo'=>'0.1'], 0);
+    $json = $u->execute($this->mssql, 'alpha', '14.0.100', ['khmer_angkor'=>'1.0.2', 'foo'=>'0.1'], 0, 1);
     $this->assertNotEmpty($json);
     $data = json_decode($json);
     $this->assertNotNull($data);

--- a/tools/2020/ReleaseSchedule.php
+++ b/tools/2020/ReleaseSchedule.php
@@ -1,0 +1,52 @@
+<?php
+  declare(strict_types=1);
+
+  namespace Keyman\Site\com\keyman\api;
+
+  class ReleaseSchedule {
+
+    /**
+     * This function helps us to do a gradual roll out of a major upgrade of Keyman
+     * on Windows, by testing the current time against both the date of the release
+     * and the minute of the hour, so that users checking only at specific times
+     * receive the update.
+     *
+     * @param string releaseDate    yyyy-mm-dd date that major version was released
+     * @param int    currentTime    Unix timestamp of current time
+     * @return bool  true if the request should be presented with the upgrade
+     */
+    public static function DoesRequestMeetSchedule(string $releaseDate, int $currentTime = null): bool {
+      // This is an arbitrary schedule; see for example Chrome's release schedule:
+      // https://chromium.googlesource.com/chromium/src/+/master/docs/process/release_cycle.md
+      $schedule = [
+        5 => 3,   // 5 days for 3 minutes, 5% of user base
+        10 => 6,  // 10 days for 6 minutes / 10%
+        15 => 18, // 15 days for 18 minutes / 30%
+        20 => 36  // 20 days for 36 minutes / 60%
+      ];
+
+      $releaseDate = new \DateTime($releaseDate);
+      $currentDate = new \DateTime();
+      if($currentTime) {
+        $currentDate->setTimestamp($currentTime);
+      }
+
+      $currentTime = getdate($currentDate->getTimestamp());
+
+      if($currentDate < $releaseDate) {
+        // Don't match if current date before release date
+        return FALSE;
+      }
+
+      $interval = $currentDate->diff($releaseDate);
+
+      foreach($schedule as $days => $minutes) {
+        if($interval->days <= $days) {
+          return $currentTime['minutes'] < $minutes;
+        }
+      }
+
+      // It's been more than 20 days so everyone gets the update now
+      return TRUE;
+    }
+  }

--- a/tools/onlineupdate.php
+++ b/tools/onlineupdate.php
@@ -69,13 +69,14 @@
     private function CheckVersionResponse($tier, $tiers, $platform, $InstalledVersion) {
       if(!isset($tiers[$tier])) return FALSE;
       $tierdata = $tiers[$tier];
-      if($this->IsSameMajorVersion($tierdata->version, $InstalledVersion)) {
-        // TODO: Offer upgrades for MAJOR.x.x.x versions.
-        // We still don't support staying on alpha or beta tier once a version
-        // hits stable. We need to review the upgrade strategies for these.
-        // Once a version is older than latest stable, we also don't offer updates for it;
-        // this is probably also wrong.
 
+      // TODO: alpha should always stay on alpha, major->major
+      //       beta should migrate to stable
+      //       stable should always stay on stable, major->major
+
+      // TODO: support filename change from keymandesktop to keyman
+
+      //if($this->IsSameMajorVersion($tierdata->version, $InstalledVersion)) {
         $files = get_object_vars($tierdata->files);
         foreach($files as $file => $filedata) {
           // This is currently tied to Windows -- for other platforms we need to change this
@@ -84,7 +85,7 @@
             return $filedata;
           }
         }
-      }
+      //}
       return FALSE;
     }
 

--- a/web.config
+++ b/web.config
@@ -154,18 +154,18 @@
 
         <rule name="desktop/10.0-13.0/update" stopProcessing="true">
           <match url="^desktop/(10|11|12|13)\.[0-9]/update(.*)" />
-          <action type="Rewrite" url="/script/desktop/10.0/update/index.php{R:1}" />
+          <action type="Rewrite" url="/script/desktop/10.0/update/index.php{R:2}" appendQueryString="true" />
         </rule>
 
         <rule name="desktop/10.0/exception" stopProcessing="true">
           <!-- Note: this endpoint is also used by developer -->
           <match url="^desktop/[1-9][0-9]\.[0-9]/exception(.*)" />
-          <action type="Rewrite" url="/script/desktop/10.0/exception/index.php{R:1}" />
+          <action type="Rewrite" url="/script/desktop/10.0/exception/index.php{R:2}" appendQueryString="true" />
         </rule>
 
         <rule name="desktop/10.0/isonline" stopProcessing="true">
           <match url="^desktop/[1-9][0-9]\.[0-9]/isonline(/?)$" />
-          <action type="Rewrite" url="/script/desktop/10.0/isonline/index.php" />
+          <action type="Rewrite" url="/script/desktop/10.0/isonline/index.php" appendQueryString="true" />
         </rule>
 
         <rule name="desktop/10.0/submitdiag" stopProcessing="true">


### PR DESCRIPTION
Fixes keymanapp/keyman#1635.

This implements the major version upgrade functionality for Keyman on Windows. There are quite a few nuances to take into account:

1. We offer updates for alpha to alpha versions -- they'll never go to beta or stable.
2. Beta versions will be updated to stable, as the beta tier goes stale between major releases.
3. Stable only ever upgrades to stable.
4. We rollout stable major releases gradually to ensure that we don't have hundreds of thousands of users updating at once.
5. Keyman Desktop 10.0 does not currently do major version upgrades, because of a limitation in the installer which means that user keyboards are not migrated (see keymanapp/keyman#3865).
6. This does not support upgrading versions earlier than 10.0 at all.
7. This upgrades Keyman Desktop 11.0 onwards, and Keyman Developer 11.0-13.0. Keyman Developer 14.0 upgrades are awaiting code updates in the keymanapp/keyman repo, and will likely require a new PR on api.keyman.com for full support also (keymanapp/keyman#3846).
8. If a user manually checks for updates, they'll receive the major version upgrade offer immediately, while the automated weekly check still works in the rollout schedule. (Corresponding keymanapp/keyman PR to come).

Whew. Online updates are supposed to be easy, right?

I have not yet written tests for the various permutations of manual vs automatic update checks and tiers. I am currently pretending I don't need to because it's not a fun job... and will probably require some additional refactoring in ordre for ReleaseSchedule to be side-effect free when used from WindowsUpdateCheck etc.