### PR TITLE
feat: Developer major version upgrade support

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -164,3 +164,24 @@ Documentation at https://help.keyman.com/developer/cloud/package-version
 * Fixed bugs with missing .kmp files
 * Added deprecation links
 * Updated .kmp URLs to use keyman.com/go/package format
+
+------------------------------------------------------------
+
+# windows-update
+
+* windows-update.json
+
+## 2020-07-23 1.0
+* Initial version 1.0 (alpha)
+
+## 2020-11-17 1.0.1
+* Relaxed `file` to `optional-file` to allow for responses without an update available.
+
+------------------------------------------------------------
+
+# developer-update
+
+* developer-update.json
+
+## 2020-11-17 1.0
+* Initial version 1.0 (alpha)

--- a/schemas/developer-update/14.0/developer-update.json
+++ b/schemas/developer-update/14.0/developer-update.json
@@ -11,9 +11,13 @@
       "additionalProperties": true,
       "properties": {
         "developer": {
-          "$ref": "#/definitions/file"
+          "$ref": "#/definitions/optional-file"
         }
       }
+    },
+
+    "optional-file": {
+      "anyOf": [{ "$ref": "#/definitions/file" }, { "type": "boolean" }]
     },
 
     "file": {

--- a/schemas/developer-update/14.0/developer-update.json
+++ b/schemas/developer-update/14.0/developer-update.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$ref": "#/definitions/developer-update",
+
+  "definitions": {
+    "developer-update": {
+      "type": "object",
+      "required": [
+        "developer"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "developer": {
+          "$ref": "#/definitions/file"
+        }
+      }
+    },
+
+    "file": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "date",
+        "platform",
+        "stability",
+        "file",
+        "md5",
+        "type",
+        "build",
+        "size",
+        "url"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "stability": {
+          "type": "string"
+        },
+        "file": {
+          "type": "string"
+        },
+        "md5": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "build": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/script/developer/14.0/update/DeveloperUpdateCheck.php
+++ b/script/developer/14.0/update/DeveloperUpdateCheck.php
@@ -23,12 +23,12 @@
       $this->isManual = !empty($isManual);
 
       $developer_update = [];
-      $developer_update['developer'] = $this->BuildKeymanDesktopVersionResponse($tier, $appVersion, self::SETUP_REGEX);
+      $developer_update['developer'] = $this->BuildKeymanDeveloperVersionResponse($tier, $appVersion, self::SETUP_REGEX);
 
       return json_encode($developer_update, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 
-    private function BuildKeymanDesktopVersionResponse($tier, $InstalledVersion, $regex) {
+    private function BuildKeymanDeveloperVersionResponse($tier, $InstalledVersion, $regex) {
       if(empty($this->DownloadVersions)) {
         $this->DownloadVersions = DownloadsApi::Instance()->GetPlatformVersion("developer");
         if($this->DownloadVersions === NULL) {

--- a/script/developer/14.0/update/DeveloperUpdateCheck.php
+++ b/script/developer/14.0/update/DeveloperUpdateCheck.php
@@ -1,0 +1,102 @@
+<?php
+  declare(strict_types=1);
+
+  namespace Keyman\Site\com\keyman\api;
+
+  require_once __DIR__ . '/../../../../tools/autoload.php';
+
+  use Keyman\Site\com\keyman\api\DownloadsApi;
+  use Keyman\Site\Common\KeymanHosts;
+
+  class DeveloperUpdateCheck {
+    const SETUP_REGEX = '/^keymandeveloper-.+\.exe/';
+
+    private $isManual;
+
+    public function execute($mssql, $tier, $appVersion, $isManual) {
+
+      $this->mssql = $mssql;
+
+      $isUpdate = empty($isUpdate) ? 0 : 1;
+      $this->isManual = !empty($isManual);
+
+      $developer_update = [];
+      $developer_update['developer'] = $this->BuildKeymanDesktopVersionResponse($tier, $appVersion, self::SETUP_REGEX);
+
+      return json_encode($developer_update, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
+
+    private function BuildKeymanDesktopVersionResponse($tier, $InstalledVersion, $regex) {
+      if(empty($this->DownloadVersions)) {
+        $this->DownloadVersions = DownloadsApi::Instance()->GetPlatformVersion("developer");
+        if($this->DownloadVersions === NULL) {
+          fail('Unable to download or decode version data from '.KeymanHosts::Instance()->downloads_keyman_com, 500);
+        }
+
+        if(!isset($this->DownloadVersions->developer)) {
+          fail("Unable to find {developer} key in ".KeymanHosts::Instance()->downloads_keyman_com." data", 500);
+        }
+      }
+
+      // Check each of the tiers for the one that matches the major version.
+      // This gets us upgrades on alpha, beta and stable tiers.
+      $tiers = get_object_vars($this->DownloadVersions->developer);
+
+      // We will support staying on alpha tier even once a version
+      // hits stable. This is correct, with major upgrade support, as
+      // that'll mean the user will transition to a new version on the
+      // same tier (i.e. always staying bleeding edge). However, for beta
+      // users, the assumption will be that they should upgrade to the stable
+      // release once it is available, as the beta branch will go stale and
+      // they will receive no further updates on it otherwise (until next beta
+      // period, anyway).
+      switch($tier) {
+        case 'alpha':
+          return $this->CheckVersionResponse($tier, $tiers, $InstalledVersion, $regex);
+        case 'beta':
+          $response = $this->CheckVersionResponse($tier, $tiers, $InstalledVersion, $regex);
+          if($response === FALSE)
+            $response = $this->CheckVersionResponse('stable', $tiers, $InstalledVersion, $regex);
+          return $response;
+        case 'stable':
+          return $this->CheckVersionResponse($tier, $tiers, $InstalledVersion, $regex);
+        default:
+          fail('Unexpected tier '.$tier, 500);
+      }
+    }
+
+    private function CheckVersionResponse($tier, $tiers, $InstalledVersion, $regex) {
+      if(!isset($tiers[$tier])) return FALSE;
+      $tierdata = $tiers[$tier];
+
+      $files = get_object_vars($tierdata->files);
+      foreach($files as $file => $filedata) {
+        if(preg_match($regex, $file)) {
+
+          if(!$this->isManual &&
+              $tier == 'stable' &&
+              !$this->IsSameMajorVersion($InstalledVersion, $tierdata->version)) {
+            // We're going to stagger upgrades by the minute of the hour for the check, to
+            // ensure we don't have everyone major-update at once and potentially cause us
+            // grief. This will mean that we need additional PRs to update this value; that
+            // gives us tracking automatically, so I'm good with that.
+            if(!ReleaseSchedule::DoesRequestMeetSchedule($filedata->date)) {
+              return FALSE;
+            }
+          }
+
+          $filedata->url = KeymanHosts::Instance()->downloads_keyman_com . "/developer/$tier/{$filedata->version}/{$file}";
+          return $filedata;
+        }
+      }
+
+      return FALSE;
+    }
+
+    private function IsSameMajorVersion($v1, $v2) {
+      if(empty($v1) || empty($v2)) return FALSE;
+      $v1 = explode('.', $v1);
+      $v2 = explode('.', $v2);
+      return $v1[0] == $v2[0];
+    }
+  }

--- a/script/developer/14.0/update/DeveloperUpdateCheck.php
+++ b/script/developer/14.0/update/DeveloperUpdateCheck.php
@@ -70,6 +70,7 @@
     private function CheckVersionResponse($tier, $tiers, $InstalledVersion, $regex) {
       if(!isset($tiers[$tier])) return FALSE;
       $tierdata = $tiers[$tier];
+      if(is_array($tierdata->files)) return FALSE;
 
       $files = get_object_vars($tierdata->files);
       foreach($files as $file => $filedata) {

--- a/script/developer/14.0/update/index.php
+++ b/script/developer/14.0/update/index.php
@@ -1,0 +1,22 @@
+<?php
+  require_once __DIR__ . '/../../../../tools/base.inc.php';
+  require_once __DIR__ . '/../../../../tools/util.php';
+  require_once __DIR__ . '/../../../../tools/db/db.php';
+  require_once __DIR__ . '/DeveloperUpdateCheck.php';
+
+  json_response();
+  allow_cors();
+
+  if(!isset($_REQUEST['version'])) {
+    /* Invalid update check */
+    fail('Invalid Parameters - expected version parameter', 401);
+  }
+
+  $tier = isset($_REQUEST['tier']) ? $_REQUEST['tier'] : 'stable';
+
+  $isManual = empty($_REQUEST['manual']) ? 0 : 1;
+
+  $mssql = Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
+
+  $u = new Keyman\Site\com\keyman\api\DeveloperUpdateCheck();
+  echo $u->execute($mssql, $tier, $_REQUEST['version'], $isManual);

--- a/tests/DeveloperUpdateCheckTest.php
+++ b/tests/DeveloperUpdateCheckTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Keyman\Site\com\keyman\api\tests;
+
+require_once(__DIR__ . '/../tools/base.inc.php');
+require_once(__DIR__ . '/../script/developer/14.0/update/DeveloperUpdateCheck.php');
+require_once(__DIR__ . '/ApiTestCase.php');
+require_once(__DIR__ . '/TestUtils.inc.php');
+
+use Keyman\Site\com\keyman\api\tests\ApiTestCase;
+
+final class DeveloperUpdateCheckTest extends ApiTestCase
+{
+  private const SchemaFilename = "/developer-update/14.0/developer-update.json";
+  private $mssql, $schema;
+
+  public function setUp(): void
+  {
+    $this->mssql = \Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
+    $this->schema = TestUtils::LoadJSONSchema(self::SchemaFilename);
+  }
+
+  public function testSimpleResultValidatesAgainstSchema(): void
+  {
+    $u = new \Keyman\Site\com\keyman\api\DeveloperUpdateCheck();
+    $json = $u->execute($this->mssql, 'alpha', '14.0.100', 1);
+
+    $this->assertNotEmpty($json);
+    $data = json_decode($json);
+    $this->assertNotNull($data);
+
+    // This will throw an exception if it does not pass
+    $this->schema->in($data);
+
+    // TODO: add some more realism!
+    $this->assertJsonStringEqualsJsonFile(__DIR__ . '/fixtures/DeveloperUpdateCheck.14.0.json', $json);
+  }
+}

--- a/tests/DeveloperUpdateCheckTest.php
+++ b/tests/DeveloperUpdateCheckTest.php
@@ -20,11 +20,14 @@ final class DeveloperUpdateCheckTest extends ApiTestCase
     $this->schema = TestUtils::LoadJSONSchema(self::SchemaFilename);
   }
 
-  public function testSimpleResultValidatesAgainstSchema(): void
+  // Note, in these tests, we send earlier version numbers in. This is fine as we
+  // don't ever actually restrict this API to 14.0 or later versions, and we do so
+  // in order to exercise major version upgrade scenarios.
+
+  private function getJsonString($tier, $appVersion, $isManual, $currentTime = null)
   {
     $u = new \Keyman\Site\com\keyman\api\DeveloperUpdateCheck();
-    $json = $u->execute($this->mssql, 'alpha', '14.0.100', 1);
-
+    $json = $u->execute($this->mssql, $tier, $appVersion, $isManual, $currentTime);
     $this->assertNotEmpty($json);
     $data = json_decode($json);
     $this->assertNotNull($data);
@@ -32,7 +35,77 @@ final class DeveloperUpdateCheckTest extends ApiTestCase
     // This will throw an exception if it does not pass
     $this->schema->in($data);
 
-    // TODO: add some more realism!
+    return $json;
+  }
+
+  private function getJson($tier, $appVersion, $isManual, $currentTime = null)
+  {
+    return json_decode($this->getJsonString($tier, $appVersion, $isManual, $currentTime));
+  }
+
+  public function testSimpleResultValidatesAgainstSchema(): void
+  {
+    $json = $this->getJsonString('alpha', '14.0.100', 1);
     $this->assertJsonStringEqualsJsonFile(__DIR__ . '/fixtures/DeveloperUpdateCheck.14.0.json', $json);
+  }
+
+  public function testAlphaStaysInAlpha(): void
+  {
+    $json = $this->getJson('alpha', '13.0.100', 1);
+    $this->assertEquals('alpha', $json->developer->stability);
+    $this->assertEquals('14.0.181', $json->developer->version);
+  }
+
+  public function testBetaUpgradesToStable(): void
+  {
+    $json = $this->getJson('beta', '13.0.77', 1);
+    var_dump($json);
+    $this->assertEquals('stable', $json->developer->stability);
+    $this->assertEquals('13.0.115.0', $json->developer->version);
+  }
+
+  public function testStableStaysInStable(): void
+  {
+    $json = $this->getJson('stable', '12.0.10', 1);
+    $this->assertEquals('stable', $json->developer->stability);
+    $this->assertEquals('13.0.115.0', $json->developer->version);
+  }
+
+  public function testStableGetsDelayedRollout(): void
+  {
+    // test 1 day after release
+    // from fixture, 13.0.115.0 was released 2020-10-30
+    // rollout schedule is defined in ReleaseSchedule and is based on minute of the hour
+    // mktime is h:m:s, m/d/y (yuk!)
+
+    // out-of-schedule
+    $json = $this->getJson('stable', '12.0.10', 0, mktime(0, 20, 0, 10, 31, 2020));
+    $this->assertFalse($json->developer, 'should not be offered release (1 day, 20 minutes)');
+
+    // in-schedule
+    $json = $this->getJson('stable', '12.0.10', 0, mktime(0, 1, 0, 10, 31, 2020));
+    $this->assertEquals('13.0.115.0', $json->developer->version, 'should be offered release (1 day, 1 minute)');
+
+    // minor update, out-of-schedule
+    $json = $this->getJson('stable', '13.0.107.0', 0, mktime(0, 20, 0, 10, 31, 2020));
+    $this->assertEquals('13.0.115.0', $json->developer->version, 'should be offered release');
+
+    // test 30 days after release
+
+    // in-schedule, 59 minutes after hour
+    $json = $this->getJson('stable', '12.0.10', 0, mktime(0, 59, 0, 11, 28, 2020));
+    $this->assertEquals('13.0.115.0', $json->developer->version, 'should be offered release');
+
+    // in-schedule, 1 minute after hour
+    $json = $this->getJson('stable', '12.0.10', 0, mktime(0, 1, 0, 11, 28, 2020));
+    $this->assertEquals('13.0.115.0', $json->developer->version, 'should be offered release');
+
+    // minor update, in-schedule
+    $json = $this->getJson('stable', '13.0.107.0', 0, mktime(0, 59, 0, 11, 28, 2020));
+    $this->assertEquals('13.0.115.0', $json->developer->version, 'minor update should be offered release');
+
+    // out-of-schedule, major update, test manual check
+    $json = $this->getJson('stable', '12.0.10', 1, mktime(0, 20, 0, 10, 31, 2020));
+    $this->assertEquals('13.0.115.0', $json->developer->version, 'major update manual check should be offered release');
   }
 }

--- a/tests/fixtures/DeveloperUpdateCheck.14.0.json
+++ b/tests/fixtures/DeveloperUpdateCheck.14.0.json
@@ -1,0 +1,15 @@
+{
+  "developer": {
+      "name": "Keyman Developer",
+      "version": "14.0.181",
+      "date": "2020-11-13",
+      "platform": "win",
+      "stability": "alpha",
+      "file": "keymandeveloper-14.0.181.exe",
+      "md5": "DEF176FDF7D2AF9D1636902625567753",
+      "type": "exe",
+      "build": "181",
+      "size": 97463784,
+      "url": "https://downloads.keyman.com/developer/alpha/14.0.181/keymandeveloper-14.0.181.exe"
+  }
+}

--- a/tests/fixtures/downloads.keyman.com/version/developer/2.0.json
+++ b/tests/fixtures/downloads.keyman.com/version/developer/2.0.json
@@ -1,0 +1,91 @@
+{
+  "developer": {
+      "alpha": {
+          "version": "14.0.181",
+          "files": {
+              "keymandeveloper-14.0.181.exe": {
+                  "name": "Keyman Developer",
+                  "version": "14.0.181",
+                  "date": "2020-11-13",
+                  "platform": "win",
+                  "stability": "alpha",
+                  "file": "keymandeveloper-14.0.181.exe",
+                  "md5": "DEF176FDF7D2AF9D1636902625567753",
+                  "type": "exe",
+                  "build": "181",
+                  "size": 97463784
+              },
+              "kmcomp-14.0.181.zip": {
+                  "name": "Keyman Developer Command-Line Compiler",
+                  "version": "14.0.181",
+                  "date": "2020-11-13",
+                  "platform": "win",
+                  "stability": "alpha",
+                  "file": "kmcomp-14.0.181.zip",
+                  "md5": "5E3A6559C403BCD5F5AC060640C49C1A",
+                  "type": "zip",
+                  "build": "181",
+                  "size": 6186737
+              }
+          }
+      },
+      "beta": {
+          "version": "13.0.76.0",
+          "files": {
+              "keymandeveloper-13.0.76.0.exe": {
+                  "name": "Keyman Developer",
+                  "version": "13.0.76.0",
+                  "date": "2020-02-18",
+                  "platform": "win",
+                  "stability": "beta",
+                  "file": "keymandeveloper-13.0.76.0.exe",
+                  "md5": "11BAE0CBFD9EFFAF86A64E070CD17E55",
+                  "type": "exe",
+                  "build": "76",
+                  "size": 99546672
+              },
+              "kmcomp-13.0.76.0.zip": {
+                  "name": "Keyman Developer Command-Line Compiler",
+                  "version": "13.0.76.0",
+                  "date": "2020-02-18",
+                  "platform": "win",
+                  "stability": "beta",
+                  "file": "kmcomp-13.0.76.0.zip",
+                  "md5": "1663D6A8A205EEC48447E09CEDF803EA",
+                  "type": "zip",
+                  "build": "76",
+                  "size": 6175443
+              }
+          }
+      },
+      "stable": {
+          "version": "13.0.115.0",
+          "files": {
+              "keymandeveloper-13.0.115.0.exe": {
+                  "name": "Keyman Developer",
+                  "version": "13.0.115.0",
+                  "date": "2020-10-30",
+                  "platform": "win",
+                  "stability": "stable",
+                  "file": "keymandeveloper-13.0.115.0.exe",
+                  "md5": "89368F684C26CE921CF5C09AD13D47ED",
+                  "type": "exe",
+                  "build": "115",
+                  "size": 99502856
+              },
+              "kmcomp-13.0.115.0.zip": {
+                  "name": "Keyman Developer Command-Line Compiler",
+                  "version": "13.0.115.0",
+                  "date": "2020-10-30",
+                  "platform": "win",
+                  "stability": "stable",
+                  "file": "kmcomp-13.0.115.0.zip",
+                  "md5": "9A56C4866D487619549FC0EA59637A28",
+                  "type": "zip",
+                  "build": "115",
+                  "size": 6187389
+              }
+          }
+      }
+  }
+}

--- a/web.config
+++ b/web.config
@@ -173,11 +173,18 @@
           <action type="Rewrite" url="/script/desktop/10.0/submitdiag/index.php" appendQueryString="true" />
         </rule>
 
-        <!-- Keyman Developer 10.0, 11.0, 12.0, etc API endpoints -->
+        <!-- Keyman Developer 10.0 - 13.0 API endpoints -->
 
         <rule name="developer/10.0/update" stopProcessing="true">
+          <match url="^developer/(10|11|12|13)\.0/update(.*)" />
+          <action type="Rewrite" url="/script/developer/10.0/update/index.php{R:2}" appendQueryString="true" />
+        </rule>
+
+        <!-- KEyman Developer 14.0+ API endpoints -->
+
+        <rule name="developer/14.0+/update" stopProcessing="true">
           <match url="^developer/[1-9][0-9]\.[0-9]/update(.*)" />
-          <action type="Rewrite" url="/script/developer/10.0/update/index.php{R:1}" />
+          <action type="Rewrite" url="/script/developer/14.0/update/index.php{R:1}" appendQueryString="true" />
         </rule>
 
         <!-- Rewrites for 10.0, 11.0, 12.0, 13.0 locale download from tavultesoft.com -->


### PR DESCRIPTION
Relates to keymanapp/keyman#3846.

Adds API endpoint for Keyman Developer 14.0 and later versions which supports tiers and manual updates. Adds basic unit test for same.

See also keymanapp/keyman#3868.