### PR TITLE
chore: sync common files

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -17,12 +17,12 @@
     public
       $s_keyman_com, $api_keyman_com, $help_keyman_com, $downloads_keyman_com,
       $keyman_com, $keymanweb_com, $r_keymanweb_com, $blog_keyman_com,
-      $donate_keyman_com;
+      $donate_keyman_com, $translate_keyman_com;
 
     public
       $s_keyman_com_host, $api_keyman_com_host, $help_keyman_com_host, $downloads_keyman_com_host,
       $keyman_com_host,  $keymanweb_com_host, $r_keymanweb_com_host, $blog_keyman_com_host,
-      $donate_keyman_com_host;
+      $donate_keyman_com_host, $translate_keyman_com_host;
 
     private $tier;
 
@@ -40,6 +40,27 @@
 
     public static function Rebuild() {
       self::$instance = new KeymanHosts();
+    }
+
+    /**
+     * Returns $contents after regex'ing the Keyman live hosts for Markdown files
+     * @param $contents
+     * @return $contents
+     */
+    public function fixupHostReferences($contents) {
+      // Regex Keyman hosts
+      $contents = str_replace("https://s.keyman.com", $this->s_keyman_com, $contents);
+      $contents = str_replace("https://api.keyman.com", $this->api_keyman_com, $contents);
+      $contents = str_replace("https://help.keyman.com", $this->help_keyman_com, $contents);
+      $contents = str_replace("https://downloads.keyman.com", $this->downloads_keyman_com, $contents);
+      $contents = str_replace("https://keyman.com", $this->keyman_com, $contents);
+      $contents = str_replace("https://keymanweb.com", $this->keymanweb_com, $contents);
+      $contents = str_replace("https://r.keymanweb.com", $this->r_keymanweb_com, $contents);
+      $contents = str_replace("https://blog.keyman.com", $this->blog_keyman_com, $contents);
+      $contents = str_replace("https://donate.keyman.com", $this->donate_keyman_com, $contents);
+      $contents = str_replace("https://translate.keyman.com", $this->translate_keyman_com, $contents);
+
+      return $contents;
     }
 
     function __construct() {
@@ -72,6 +93,7 @@
 
       $this->blog_keyman_com = "https://blog.keyman.com";
       $this->donate_keyman_com = "https://donate.keyman.com";
+      $this->translate_keyman_com = "https://translate.keyman.com";
 
       if(in_array($this->tier, [KeymanHosts::TIER_STAGING, KeymanHosts::TIER_TEST])) {
         // As we build more staging areas, change these over as well. Assumption that we'll stage across multiple sites is a
@@ -103,5 +125,6 @@
       $this->keymanweb_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->keymanweb_com);
       $this->r_keymanweb_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->r_keymanweb_com);
       $this->donate_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->donate_keyman_com);
+      $this->translate_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->translate_keyman_com);
     }
   }

--- a/_common/MarkdownHost.php
+++ b/_common/MarkdownHost.php
@@ -1,0 +1,66 @@
+<?php
+  declare(strict_types=1);
+
+  namespace Keyman\Site\Common;
+
+  use Keyman\Site\Common\KeymanHosts;
+
+  class MarkdownHost {
+    private $content, $pagetitle;
+
+    function PageTitle() {
+      return $this->pagetitle;
+    }
+
+    function Content() {
+      return $this->content;
+    }
+
+    function __construct($file) {
+      $this->pagetitle = 'TODO'; // If page title is not set, this hints to the developer to fix it
+
+      $file = realpath(__DIR__ . '/../') . DIRECTORY_SEPARATOR . $file;
+      $contents = trim(file_get_contents($file));
+      $contents = str_replace("\r\n", "\n", $contents);
+
+      $contents = KeymanHosts::Instance()->fixupHostReferences($contents);
+
+      // This header specification comes from YAML originally and is not common across
+      // markdown implementations. While Parsedown does not currently parse this out,
+      // it seems a sensible approach to use. The header section is delineated by `---`
+      // and `---` must be the first three characters of the file (no BOM!); note that
+      // the full spec supports metadata sections anywhere but we only support top-of-file.
+      //
+      // Currently we support only the 'title' keyword, and it must be a plain text title.
+      //
+      // ---
+      // keyword: content
+      // keyword: content
+      // ---
+      //
+      // source: https://yaml.org/spec/1.2/spec.html#id2760395
+      // source: https://pandoc.org/MANUAL.html#extension-yaml_metadata_block
+      //
+      if(preg_match('/^---\n(.+)\n---\n(.+)/s', $contents, $match)) {
+        $metadata = $match[1];
+        $contents = $match[2];
+      } else {
+        $metadata = 'title: untitled';
+      }
+
+      if(preg_match('/^title: (.+)/', $metadata, $match)) {
+        $this->pagetitle = $match[1];
+      } else {
+        $this->pagetitle = 'Untitled';
+      }
+
+      // Performs the parsing + prettification of Markdown for display through PHP.
+      $Parsedown = new \ParsedownExtra();
+
+      // Does the magic.
+      $this->content =
+       "<h1>" . htmlentities($this->pagetitle) . "</h1>\n" .
+       $Parsedown->text($contents);
+    }
+  }
+

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
         "php-http/curl-client": "^2.1",
         "swaggest/json-schema": "^0.12.29",
         "guzzlehttp/guzzle": "^6.5",
-        "google/apiclient": "^2.0"
+        "google/apiclient": "^2.0",
+        "erusev/parsedown": "^1.7",
+        "erusev/parsedown-extra": "^0.8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26e009f3d2b08f82c3e472052cd359eb",
+    "content-hash": "e4b03e2c0d24dd68904b3673b7bbc623",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -112,6 +112,99 @@
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "time": "2020-04-23T11:49:37+00:00"
+        },
+        {
+            "name": "erusev/parsedown",
+            "version": "1.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "time": "2019-12-30T22:54:17+00:00"
+        },
+        {
+            "name": "erusev/parsedown-extra",
+            "version": "0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown-extra.git",
+                "reference": "91ac3ff98f0cea243bdccc688df43810f044dcef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown-extra/zipball/91ac3ff98f0cea243bdccc688df43810f044dcef",
+                "reference": "91ac3ff98f0cea243bdccc688df43810f044dcef",
+                "shasum": ""
+            },
+            "require": {
+                "erusev/parsedown": "^1.7.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "ParsedownExtra": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "An extension of Parsedown that adds support for Markdown Extra.",
+            "homepage": "https://github.com/erusev/parsedown-extra",
+            "keywords": [
+                "markdown",
+                "markdown extra",
+                "parsedown",
+                "parser"
+            ],
+            "time": "2019-12-30T23:20:37+00:00"
         },
         {
             "name": "firebase/php-jwt",


### PR DESCRIPTION
This synchronises the new MarkdownHost class between keymanapp/keyman.com#192 and api.keyman.com.

Note that MarkdownHost is unlikely to be used on api.keyman.com but we need to keep the _common folder in sync anyway.