### PR TITLE
fix: php on stable does not support variable types

### DIFF
--- a/tools/onlineupdate.php
+++ b/tools/onlineupdate.php
@@ -212,7 +212,7 @@
      * @param int    currentTime    Unix timestamp of current time
      * @return bool  true if the request should be presented with the upgrade
      */
-    public static function DoesRequestMeetSchedule(string $releaseDate, int $currentTime = null): bool {
+    public static function DoesRequestMeetSchedule($releaseDate, $currentTime = null) {
       // This is an arbitrary schedule; see for example Chrome's release schedule:
       // https://chromium.googlesource.com/chromium/src/+/master/docs/process/release_cycle.md
       $schedule = [


### PR DESCRIPTION
onlineupdate.php was return 500 errors on stable site after update as the version of PHP on stable does not support types, unlike the version on staging.