### PR TITLE
chore: make major upgrade available to all users

### DIFF
--- a/tools/onlineupdate.php
+++ b/tools/onlineupdate.php
@@ -85,7 +85,7 @@
 
             // For the initial rollout of this functionality, our stable release is 13.0, so
             // we want to manually set the release date to around the time this PR lands.
-            $date = $this->IsSameMajorVersion('13.0', $tierdata->version) ? '2020-11-18' : $filedata->date;
+            $date = $this->IsSameMajorVersion('13.0', $tierdata->version) ? /*'2020-11-18'*/ '2020-01-01' : $filedata->date;
 
             if(!ReleaseSchedule::DoesRequestMeetSchedule($date)) {
               return FALSE;


### PR DESCRIPTION
Setting the release date of 13.0 to 2020-01-01 has the effect of making it available to all users of earlier versions; we haven't had any reported issues with the upgrade so wanting to try and get more users to update.