### PR TITLE
fix: cached keyboard data not refreshing

### DIFF
--- a/App_Data/jobs/continuous/database_build/run.bat
+++ b/App_Data/jobs/continuous/database_build/run.bat
@@ -11,7 +11,7 @@ echo Triggering database rebuild
 echo Building > \home\site\wwwroot\.data\BUILDING
 del \home\site\wwwroot\.data\MUST_REBUILD
 cd \home\site\wwwroot
-call composer run-script --timeout=0 build
+call composer run-script --timeout=0 build -f
 del \home\site\wwwroot\.data\BUILDING
 
 rem We'll exit the script (Kudu will restart it) so we get logs for subsequent runs in Kudu


### PR DESCRIPTION
The keyboard build web job needs to ignore the cache in order to always get the latest keyboard and model data.

In theory we could make this signal only for the keyboard and model data and not for the other standards data, but I think that this will be okay anyway, as we don't run more than a handful of builds a day.