### PR TITLE
fix: related keyboards marked as deprecated

### DIFF
--- a/tools/db/build/search-prepare-data.sql
+++ b/tools/db/build/search-prepare-data.sql
@@ -25,11 +25,11 @@ delete from t_ethnologue_language_index where nametype='LP' or nametype='DP';
 
 update t_keyboard
   set deprecated = 1
-  where exists (select * from t_keyboard_related kr where kr.related_keyboard_id = t_keyboard.keyboard_id);
+  where exists (select * from t_keyboard_related kr where kr.related_keyboard_id = t_keyboard.keyboard_id and kr.deprecates = 1);
 
 update t_model
   set deprecated = 1
-  where exists (select * from t_model_related mr where mr.related_model_id = t_model.model_id);
+  where exists (select * from t_model_related mr where mr.related_model_id = t_model.model_id and mr.deprecates = 1);
 
 --
 -- Any keyboard that has been replaced by another one, or is not Unicode, is marked as obsolete


### PR DESCRIPTION
The 'deprecated' flag was being ignored when the relationships between keyboards was being built.

See https://github.com/keymanapp/keyman/issues/4207#issuecomment-751243842 for original report