### PR TITLE
feat: popularity and alphabetical searches

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -17,12 +17,12 @@
     public
       $s_keyman_com, $api_keyman_com, $help_keyman_com, $downloads_keyman_com,
       $keyman_com, $keymanweb_com, $r_keymanweb_com, $blog_keyman_com,
-      $donate_keyman_com, $translate_keyman_com;
+      $donate_keyman_com, $translate_keyman_com, $sentry_keyman_com;
 
     public
       $s_keyman_com_host, $api_keyman_com_host, $help_keyman_com_host, $downloads_keyman_com_host,
       $keyman_com_host,  $keymanweb_com_host, $r_keymanweb_com_host, $blog_keyman_com_host,
-      $donate_keyman_com_host, $translate_keyman_com_host;
+      $donate_keyman_com_host, $translate_keyman_com_host, $sentry_keyman_com_host;
 
     private $tier;
 
@@ -59,6 +59,7 @@
       $contents = str_replace("https://blog.keyman.com", $this->blog_keyman_com, $contents);
       $contents = str_replace("https://donate.keyman.com", $this->donate_keyman_com, $contents);
       $contents = str_replace("https://translate.keyman.com", $this->translate_keyman_com, $contents);
+      $contents = str_replace("https://sentry.keyman.com", $this->sentry_keyman_com, $contents);
 
       return $contents;
     }
@@ -94,6 +95,7 @@
       $this->blog_keyman_com = "https://blog.keyman.com";
       $this->donate_keyman_com = "https://donate.keyman.com";
       $this->translate_keyman_com = "https://translate.keyman.com";
+      $this->sentry_keyman_com = "https://sentry.keyman.com";
 
       if(in_array($this->tier, [KeymanHosts::TIER_STAGING, KeymanHosts::TIER_TEST])) {
         // As we build more staging areas, change these over as well. Assumption that we'll stage across multiple sites is a
@@ -126,5 +128,6 @@
       $this->r_keymanweb_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->r_keymanweb_com);
       $this->donate_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->donate_keyman_com);
       $this->translate_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->translate_keyman_com);
+      $this->sentry_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->sentry_keyman_com);
     }
   }

--- a/tests/DeveloperUpdateCheckTest.php
+++ b/tests/DeveloperUpdateCheckTest.php
@@ -59,7 +59,6 @@ final class DeveloperUpdateCheckTest extends ApiTestCase
   public function testBetaUpgradesToStable(): void
   {
     $json = $this->getJson('beta', '13.0.77', 1);
-    var_dump($json);
     $this->assertEquals('stable', $json->developer->stability);
     $this->assertEquals('13.0.115.0', $json->developer->version);
   }

--- a/tests/Search20Test.php
+++ b/tests/Search20Test.php
@@ -284,11 +284,22 @@ namespace Keyman\Site\com\keyman\api\tests {
 
     public function testSearchByPopularity()
     {
-      $json = $this->s->GetSearchMatches(null, 'p:*', 1, 1);
+      $json = $this->s->GetSearchMatches(null, 'p:popularity', 1, 1);
       $json = json_decode(json_encode($json));
       $this->schema->in($json);
-      $this->assertEquals(662, $json->context->totalRows);
+      $this->assertEquals(100, $json->context->totalRows);
       $this->assertEquals('gff_amharic', $json->keyboards[0]->id);
+    }
+
+    public function testSearchAlphabetically()
+    {
+      $json = $this->s->GetSearchMatches(null, 'p:alphab', 1, 1);
+      $json = json_decode(json_encode($json));
+      // test disabled: author email in our current dataset is invalid because
+      // it contains a space. Schema is valid apart from that.
+      //$this->schema->in($json);
+      $this->assertEquals(662, $json->context->totalRows);
+      $this->assertEquals('acoli', $json->keyboards[0]->id);
     }
 
     public function testSearchExcludeObsoleteKeyboards() {

--- a/tools/db/build/sp_keyboard_search_alphabetically.sql
+++ b/tools/db/build/sp_keyboard_search_alphabetically.sql
@@ -1,0 +1,39 @@
+-- #
+-- # sp_keyboard_search_alphabetically
+-- #
+
+DROP PROCEDURE IF EXISTS sp_keyboard_search_alphabetically;
+GO
+
+CREATE PROCEDURE sp_keyboard_search_alphabetically
+  @prmPlatform nvarchar(32),
+  @prmPageNumber int,
+  @prmPageSize int
+AS
+BEGIN
+  SET NOCOUNT ON;
+
+  declare @tt_keyboard tt_keyboard_search_keyboard
+
+  declare @weight_keyboard INT = 1
+
+  -- #
+  -- # Search across keyboards
+  -- #
+
+  insert @tt_keyboard
+    select
+      *
+    from
+      f_keyboard_search_alphabetically(@prmPlatform, @weight_keyboard)
+
+  -- #
+  -- # Build final list of results; two result sets: summary data and current page result
+  -- #
+
+  SET NOCOUNT OFF;
+
+  select * from f_keyboard_search_statistics(@prmPageSize, @prmPageNumber, 0, @tt_keyboard)
+  select * from f_keyboard_search_results_ignore_downloads(@prmPageSize, @prmPageNumber, 0, @tt_keyboard)
+END
+GO


### PR DESCRIPTION
Part of keymanapp/keyman.com#206.

* Clamps popularity results to top 100 keyboards
  * `p:*` and `p:popularity` (or substring) both work
* Adds alphabetical search
  * `p:!` and `p:alphabetically` (or substring) both work

Side fixes:

* Harmonizes KeymanHosts.php with keyman.com
* Removes debug statement from DeveloperUpdateCheckTest.php