### PR TITLE
fix: improve weight for searches

### DIFF
--- a/tools/db/build/sp_keyboard_search.sql
+++ b/tools/db/build/sp_keyboard_search.sql
@@ -458,11 +458,12 @@ AS
         row_number() over(
           partition by keyboard_id
           order by
-            weight desc, -- primary order
+            sum(weight) desc, -- primary order
             match_name,  -- helps sort shorter matches earlier
             match_type   -- allows consistent results for equal weight+name
           ) as roworder
       from @tt_keyboard
+      group by keyboard_id, match_type, match_tag, match_name
     ) temp inner join
     t_keyboard k on temp.keyboard_id = k.keyboard_id left join
     t_keyboard_downloads kd on temp.keyboard_id = kd.keyboard_id


### PR DESCRIPTION
Fixes #147.

The search results for 'german' would return a set of weights for various language codes. 'de' had 5 weights and 'pdt-Latn' had 4, but both had a match on the name 'German' because 'pdt-Latn' has an alternate language name of 'German'. This meant that the actual result returned was indeterminate -- they both had the same weight.

Summing the weights for each language tag match brought 'de' higher in the match results (weight 60 vs 30).