### PR TITLE
fix: avoid missing packages with spaces or periods in id

### DIFF
--- a/script/windows/14.0/update/index.php
+++ b/script/windows/14.0/update/index.php
@@ -26,6 +26,15 @@
     if(substr($id, 0, 8) == 'package_')	{
       $PackageID = iconv("CP1252", "UTF-8", substr($id, 8, strlen($id)));
       $packages[$PackageID] = $version;
+    } else if(substr($id, 0, 10) == 'packageid_')	{
+      // PHP has a 'feature' where it silently converts space, period and other characters in
+      // incoming parameter names into underscores. So we need to pass these in parameter
+      // values instead of names. It would be nice if the tools didn't get in our way!
+      $PackageID = iconv("CP1252", "UTF-8", $version);
+      $pvid = 'packageversion_'.substr($id, 10);
+      if(isset($_REQUEST[$pvid])) {
+        $packages[$PackageID] = $_REQUEST[$pvid];
+      }
     }
   }
 


### PR DESCRIPTION
Relates to keymanapp/keyman#4886.

If a package id has a period or a space (which can happen with legacy packages), then the online update API would not find it, because of a PHP misfeature which transforms these characters in input query parameter names to underscore (really!). This seems like it is potentially impossible to work around for POST requests (`php://input` does not work for `multipart/form-data` duh), so I have added an alternative parameter layout instead. Obviously, this means that Keyman for Windows requires a corresponding update to use the new parameter layout.