### PR TITLE
chore: use Choco-Install script to retry installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         Enable-WindowsOptionalFeature -Online -FeatureName IIS-CGI -NoRestart
         Enable-WindowsOptionalFeature -Online -FeatureName IIS-ISAPIExtensions -NoRestart
         Enable-WindowsOptionalFeature -Online -FeatureName IIS-ISAPIFilter -NoRestart
-        Choco-Install -PackageName urlrewrite --no-progress
+        Choco-Install -PackageName urlrewrite -ArgumentList "--no-progress"
         Import-Module WebAdministration
         New-WebAppPool -name "NewWebSiteAppPool"  -force
         New-WebSite -name "NewWebSite" -PhysicalPath "$ENV:GITHUB_WORKSPACE" -ApplicationPool "NewWebSiteAppPool" -port 8888 -force
@@ -91,7 +91,7 @@ jobs:
     - name: Download and install SQL Server Express
       shell: powershell
       run: |
-        Choco-Install -PackageName sql-server-2019 --no-progress --params "'/IGNOREPENDINGREBOOT /INSTANCEID=KEYMANAPI /INSTANCENAME=KEYMANAPI /SAPWD=Password1! /SECURITYMODE=SQL /UPDATEENABLED=FALSE /FEATURES=SQLENGINE,FULLTEXT'"
+        Choco-Install -PackageName sql-server-2019 -ArgumentList "--no-progress", "--params", "'/IGNOREPENDINGREBOOT /INSTANCEID=KEYMANAPI /INSTANCENAME=KEYMANAPI /SAPWD=Password1! /SECURITYMODE=SQL /UPDATEENABLED=FALSE /FEATURES=SQLENGINE,FULLTEXT'"
 
     #
     # Install website PHP dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         Enable-WindowsOptionalFeature -Online -FeatureName IIS-CGI -NoRestart
         Enable-WindowsOptionalFeature -Online -FeatureName IIS-ISAPIExtensions -NoRestart
         Enable-WindowsOptionalFeature -Online -FeatureName IIS-ISAPIFilter -NoRestart
-        choco install --no-progress urlrewrite
+        Choco-Install -PackageName urlrewrite --no-progress
         Import-Module WebAdministration
         New-WebAppPool -name "NewWebSiteAppPool"  -force
         New-WebSite -name "NewWebSite" -PhysicalPath "$ENV:GITHUB_WORKSPACE" -ApplicationPool "NewWebSiteAppPool" -port 8888 -force
@@ -91,7 +91,7 @@ jobs:
     - name: Download and install SQL Server Express
       shell: cmd
       run: |
-        choco install sql-server-2019 --no-progress --params "'/IGNOREPENDINGREBOOT /INSTANCEID=KEYMANAPI /INSTANCENAME=KEYMANAPI /SAPWD=Password1! /SECURITYMODE=SQL /UPDATEENABLED=FALSE /FEATURES=SQLENGINE,FULLTEXT'"
+        Choco-Install -PackageName sql-server-2019 --no-progress --params "'/IGNOREPENDINGREBOOT /INSTANCEID=KEYMANAPI /INSTANCENAME=KEYMANAPI /SAPWD=Password1! /SECURITYMODE=SQL /UPDATEENABLED=FALSE /FEATURES=SQLENGINE,FULLTEXT'"
 
     #
     # Install website PHP dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     # Install SQL Server Developer Edition with FullText Search module
     #
     - name: Download and install SQL Server Express
-      shell: cmd
+      shell: powershell
       run: |
         Choco-Install -PackageName sql-server-2019 --no-progress --params "'/IGNOREPENDINGREBOOT /INSTANCEID=KEYMANAPI /INSTANCENAME=KEYMANAPI /SAPWD=Password1! /SECURITYMODE=SQL /UPDATEENABLED=FALSE /FEATURES=SQLENGINE,FULLTEXT'"
 


### PR DESCRIPTION
Fixes #154.

Note that Choco does not currently have support for retries (https://github.com/chocolatey/choco/issues/385).

GitHub Actions have a wrapper for `choco install` called `Choco-Install`, which automatically supports retries. Per comment at https://github.com/actions/virtual-environments/issues/3493#issuecomment-853947713, I am trying this now to see if it does the job for us.

* See actions/virtual-environments#721 for implementation of `Choco-Install`.