### PR TITLE
fix: prevent invalid final char in username

### DIFF
--- a/script/desktop/10.0/submitdiag/index.php
+++ b/script/desktop/10.0/submitdiag/index.php
@@ -140,7 +140,10 @@
   }
 
   function generate_username_from_email($email) {
-    return substr(preg_replace('/[^a-zA-Z0-9_-]/', '_', $email), 0, 20);
+    $email = substr(preg_replace('/[^a-zA-Z0-9_-]/', '_', $email), 0, 20);
+    $lastch = substr($email, -1);
+    if($lastch == '_' || $lastch == '-') $email = substr($email, 0, 19) . 'x';
+    return $email;
   }
 
   function die_errors($msg) {


### PR DESCRIPTION
Discourse only allows alphanumeric as last char in a username. This makes sure the last char is always alpha by appending 'x'. Rudimentary but should be safe.