### PR TITLE
fix: remove obsolete tests

### DIFF
--- a/tests/Search20Test.php
+++ b/tests/Search20Test.php
@@ -235,38 +235,6 @@ namespace Keyman\Site\com\keyman\api\tests {
     }
 
     /**
-     * The langtags database includes 'khw[-Arab]' but not 'khw-Latn'.
-     * Keyboard burushaski_girmanas targets a Latin script variant of this.
-     * Test the direct search for the language tag.
-     */
-    public function testSearchByCustomLanguageTag()
-    {
-      $json = $this->s->GetSearchMatches(null, 'l:id:khw-latn', 1, 1);
-      $json = json_decode(json_encode($json));
-      $this->schema->in($json);
-      $this->assertEquals(1, $json->context->totalRows);
-      $this->assertEquals('khw-latn', $json->context->text);
-      $this->assertEquals('burushaski_girminas', $json->keyboards[0]->id);
-    }
-
-    /**
-     * The langtags database includes 'khw[-Arab]' but not 'khw-Latn'.
-     * Keyboard burushaski_girmanas targets a Latin script variant of this.
-     * Validate that the search for 'Khowar' finds both Arabic and Latin script results
-     */
-    public function testSearchByLanguageFindsCustomTag()
-    {
-      $json = $this->s->GetSearchMatches(null, 'l:Khowar', 1, 1);
-      $json = json_decode(json_encode($json));
-      $this->schema->in($json);
-      $this->assertEquals(4, $json->context->totalRows);
-      $this->assertEquals('rac_khowar', $json->keyboards[0]->id);
-      $this->assertEquals('sil_khowar', $json->keyboards[1]->id);
-      $this->assertEquals('burushaski_girminas', $json->keyboards[2]->id);
-      $this->assertEquals('khowar', $json->keyboards[3]->id);
-    }
-
-    /**
      * The langtags database does not include 'pi' (Pali) without a script tag.
      * (This is not a helpful tag, but it's good for testing at this time; it is likely that
      * an update to the keyboard will correct the tag at which point we should perhaps switch


### PR DESCRIPTION
The referenced keyboard for these two tests removed the lang tag khw-latn in https://github.com/keymanapp/keyboards/pull/1776, so these tests no longer pass. I have not located any other keyboards with lang tags that are not in langtags.json at this time, so I am simply removing these tests.