### PR TITLE
fix: handle langtags reserved _tags

### DIFF
--- a/tools/db/build/build_langtags_data_script.inc.php
+++ b/tools/db/build/build_langtags_data_script.inc.php
@@ -29,12 +29,11 @@
       $sql = '';
       $n = 0;
       foreach($json as $obj) {
-        switch($obj->tag) {
-          case '_globalvar': $sql .= $this->process_globalvar($obj); break;
-          case '_phonvar': $sql .= $this->process_phonvar($obj); break;
-          case '_version': $sql .= $this->process_version($obj); break;
-          default: $sql .= $this->process_entry($obj); break;
+        if(substr($obj->tag, 0, 1) == '_') {
+          // _globalvar, _phonvar, _version, _conformance, other reserved metadata tags
+          continue;
         }
+        $sql .= $this->process_entry($obj);
         if((++$n) % 100 == 0) $sql .= "\nGO\n";
       }
 


### PR DESCRIPTION
langtags.json introduced a new metadata tag `_conformance` in release 1.2.2, which was not handled in the database build. The database build now ignores all tags starting with `_`.