### PR TITLE
fix: sum search weights when multiple instances of same term

### DIFF
--- a/tools/db/build/sp_keyboard_search.sql
+++ b/tools/db/build/sp_keyboard_search.sql
@@ -464,7 +464,11 @@ AS
             match_name,  -- helps sort shorter matches earlier
             match_type   -- allows consistent results for equal weight+name
           ) as roworder
-      from @tt_keyboard
+      from (
+        select keyboard_id, sum(weight) weight, name, match_name, match_type, match_tag
+        from @tt_keyboard
+	      group by keyboard_id, name, match_name, match_type, match_tag
+      ) tt_keyboard_summed_weights -- @tt_keyboard
     ) temp inner join
     t_keyboard k on temp.keyboard_id = k.keyboard_id left join
     v_keyboard_downloads_month kd on temp.keyboard_id = kd.keyboard_id left join


### PR DESCRIPTION
Fixes #197. (I hope!)

When multiple entries in the search sub-result match, the weights will be summed on the assumption that this means the name is more prevalent. For example, German (de) has two entries, whereas German (pdt) has only one.