### PR TITLE
chore: Update URLs

### DIFF
--- a/tools/db/build/datasources.inc.php
+++ b/tools/db/build/datasources.inc.php
@@ -6,8 +6,8 @@
     // http://www-01.sil.org/iso639-3/iso-639-3_Name_Index.tab <-- for language name index
     // https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry <-- for language subtag registry
     public const URI_LANGUAGE_SUBTAG_REGISTRY = 'https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry';
-    public const URI_ISO639_3_TAB = 'http://www-01.sil.org/iso639-3/iso-639-3.tab';
-    public const URI_ISO639_3_NAME_INDEX_TAB = 'http://www-01.sil.org/iso639-3/iso-639-3_Name_Index.tab';
+    public const URI_ISO639_3_TAB = 'https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3.tab';
+    public const URI_ISO639_3_NAME_INDEX_TAB = 'https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3_Name_Index.tab';
 
     // No longer using ethnologue live data as it's not accessible programatically (behind Cloudflare DDos protection which
     // effectively blocks scripted access).
@@ -15,10 +15,7 @@
     public const ETHNOLOGUE_COUNTRY_CODES_TAB = __DIR__ . '/../../../static-data/ethnologue_country_codes.tab'; // 'https://www.ethnologue.com/sites/default/files/CountryCodes.tab';
     public const ETHNOLOGUE_LANGUAGE_INDEX_TAB = __DIR__ . '/../../../static-data/ethnologue_language_index.tab'; // 'https://www.ethnologue.com/sites/default/files/LanguageIndex.tab';
 
-    //define('LANGTAGS', 'https://ldml.api.sil.org/langtags.json');
-    // 2020-05-25: LANGTAGS 1.1.1 is currently in staging. Once it hits release, use link above instead.
-    // We want the windows and suppress tags which are only in 1.1.1
-    public const LANGTAGS = 'https://raw.githubusercontent.com/silnrsi/langtags/master/pub/langtags.json';
+    public const LANGTAGS = 'https://ldml.api.sil.org/langtags.json';
 
     public const URI_KEYBOARD_INFO_ZIP = 'https://downloads.keyman.com/data/keyboard_info.zip';
     public const URI_MODEL_INFO_ZIP = 'https://downloads.keyman.com/data/model_info.zip';

--- a/tools/db/build/datasources.inc.php
+++ b/tools/db/build/datasources.inc.php
@@ -2,8 +2,8 @@
   // Data sources
 
   class DBDataSources {
-    // http://www-01.sil.org/iso639-3/iso-639-3.tab <-- for iso639-3 -> iso639-1 mappings
-    // http://www-01.sil.org/iso639-3/iso-639-3_Name_Index.tab <-- for language name index
+    // https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3.tab <-- for iso639-3 -> iso639-1 mappings
+    // https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3_Name_Index.tab <-- for language name index
     // https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry <-- for language subtag registry
     public const URI_LANGUAGE_SUBTAG_REGISTRY = 'https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry';
     public const URI_ISO639_3_TAB = 'https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3.tab';


### PR DESCRIPTION
This updates the links to iso-693-3 with the current link. Also update the URL for LANGTAGS with the released version instead of the staging version.