### PR TITLE
chore: Use .localhost instead of .local 🦭

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -112,9 +112,9 @@
       } else if($this->tier == KeymanHosts::TIER_TEST) {
         $this->s_keyman_com = "https://s.keyman.com";
         $this->api_keyman_com = "http://host.docker.internal:8058"; // Unique for api.keyman.com
-        $this->help_keyman_com = "https://help.keyman.com";
+        $this->help_keyman_com = "https://help.keyman-staging.com";
         $this->downloads_keyman_com = "https://downloads.keyman.com";
-        $this->keyman_com = "https://keyman.com";
+        $this->keyman_com = "https://keyman-staging.com";
         $this->keymanweb_com = "https://keymanweb.com";
         $this->r_keymanweb_com = "https://r.keymanweb.com";
       } else if($this->tier == KeymanHosts::TIER_DEVELOPMENT) {

--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -111,7 +111,7 @@
         $this->r_keymanweb_com = "https://r.keymanweb.com";
       } else if($this->tier == KeymanHosts::TIER_TEST) {
         $this->s_keyman_com = "https://s.keyman.com";
-        $this->api_keyman_com = "http://host.docker.internal:8098"; // Unique for api.keyman.com
+        $this->api_keyman_com = "http://host.docker.internal:8058"; // Unique for api.keyman.com
         $this->help_keyman_com = "https://help.keyman.com";
         $this->downloads_keyman_com = "https://downloads.keyman.com";
         $this->keyman_com = "https://keyman.com";
@@ -120,7 +120,7 @@
       } else if($this->tier == KeymanHosts::TIER_DEVELOPMENT) {
         // Locally running sites via Docker need to access "host.docker.internal:[port]"
         $this->s_keyman_com = "http://host.docker.internal:8054";
-        $this->api_keyman_com = "http://host.docker.internal:8098";
+        $this->api_keyman_com = "http://host.docker.internal:8058";
         $this->help_keyman_com = "http://host.docker.internal:8055";
         $this->downloads_keyman_com = "https://downloads.keyman.com"; // local dev domain is usually not available
         $this->keyman_com = "http://host.docker.internal:8053";

--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -5,7 +5,7 @@
 
   class KeymanHosts {
     // Four tiers. These use the following rough patterns:
-    // * development = [x.]keyman.com.local
+    // * development = [x.]keyman.com.localhost
     // * Staging = [x.]keyman-staging.com
     // * Production = [x.]keyman.com
     // * Test = GitHub actions, localhost:8888 (uses staging tier for other hosts)
@@ -87,7 +87,7 @@
         $site_protocol = 'http://';
         break;
       case KeymanHosts::TIER_DEVELOPMENT:
-        $site_suffix = '.local';
+        $site_suffix = '.localhost';
         $site_protocol = 'https://';
         break;
       }

--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -88,8 +88,10 @@
         break;
       case KeymanHosts::TIER_DEVELOPMENT:
         $site_suffix = '.localhost';
-        $site_protocol = 'https://';
+        $site_protocol = 'http://';
         break;
+      default:
+        die("tier is '$this->tier' which is invalid\n");
       }
 
       $this->blog_keyman_com = "https://blog.keyman.com";
@@ -97,7 +99,7 @@
       $this->translate_keyman_com = "https://translate.keyman.com";
       $this->sentry_keyman_com = "https://sentry.keyman.com";
 
-      if(in_array($this->tier, [KeymanHosts::TIER_STAGING, KeymanHosts::TIER_TEST])) {
+      if($this->tier == KeymanHosts::TIER_STAGING) {
         // As we build more staging areas, change these over as well. Assumption that we'll stage across multiple sites is a
         // little presumptuous but we can live with it.
         $this->s_keyman_com = "https://s.keyman.com";
@@ -107,12 +109,29 @@
         $this->keyman_com = "https://keyman-staging.com";
         $this->keymanweb_com = "https://keymanweb.com";
         $this->r_keymanweb_com = "https://r.keymanweb.com";
+      } else if($this->tier == KeymanHosts::TIER_TEST) {
+        $this->s_keyman_com = "https://s.keyman.com";
+        $this->api_keyman_com = "https://api.keyman.com";
+        $this->help_keyman_com = "https://help.keyman.com";
+        $this->downloads_keyman_com = "https://downloads.keyman.com";
+        $this->keyman_com = "https://keyman.com";
+        $this->keymanweb_com = "https://keymanweb.com";
+        $this->r_keymanweb_com = "https://r.keymanweb.com";
+      } else if($this->tier == KeymanHosts::TIER_DEVELOPMENT) {
+        // Locally running sites via Docker need to access "host.docker.internal:[port]"
+        $this->s_keyman_com = "http://host.docker.internal:8054";
+        $this->api_keyman_com = "http://host.docker.internal:8098";
+        $this->help_keyman_com = "http://host.docker.internal:8055";
+        $this->downloads_keyman_com = "https://downloads.keyman.com"; // local dev domain is usually not available
+        $this->keyman_com = "http://host.docker.internal:8053";
+        $this->keymanweb_com = "http://host.docker.internal:8057";
+        $this->r_keymanweb_com = "https://r.keymanweb.com"; /// local dev domain is usually not available
       } else {
         // TODO: allow override of these with e.g. KEYMANHOSTS_API_KEYMAN_COM='https://api.keyman.com';
         $this->s_keyman_com = "{$site_protocol}s.keyman.com{$site_suffix}";
         $this->api_keyman_com = "{$site_protocol}api.keyman.com{$site_suffix}";
         $this->help_keyman_com = "{$site_protocol}help.keyman.com{$site_suffix}";
-        $this->downloads_keyman_com = "{$site_protocol}downloads.keyman.com{$site_suffix}";
+        $this->downloads_keyman_com = "https://downloads.keyman.com"; // local dev domain is usually not available
         $this->keyman_com = "{$site_protocol}keyman.com{$site_suffix}";
         $this->keymanweb_com = "{$site_protocol}keymanweb.com{$site_suffix}";
         $this->r_keymanweb_com = "https://r.keymanweb.com"; /// local dev domain is usually not available

--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -111,7 +111,7 @@
         $this->r_keymanweb_com = "https://r.keymanweb.com";
       } else if($this->tier == KeymanHosts::TIER_TEST) {
         $this->s_keyman_com = "https://s.keyman.com";
-        $this->api_keyman_com = "https://api.keyman.com";
+        $this->api_keyman_com = "http://host.docker.internal:8098"; // Unique for api.keyman.com
         $this->help_keyman_com = "https://help.keyman.com";
         $this->downloads_keyman_com = "https://downloads.keyman.com";
         $this->keyman_com = "https://keyman.com";

--- a/_common/KeymanSentry.php
+++ b/_common/KeymanSentry.php
@@ -8,8 +8,8 @@
       if(isset($_SERVER['SERVER_NAME'])) {
         // running from web server
         $host = $_SERVER['SERVER_NAME'];
-        if(preg_match('/\.local$/', $host))
-          // If the host name is, e.g. api.keyman.com.local, then we'll assume this is a development environment
+        if(preg_match('/\.localhost$/', $host))
+          // If the host name is, e.g. api.keyman.com.localhost, then we'll assume this is a development environment
           $environment = 'development';
         else if(preg_match('/(^|\.)keyman-staging\.com$/', $host))
           $environment = 'staging';

--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,7 @@ if builder_start_action start:db; then
   if [ ! -z $(_get_docker_image_id db) ]; then
     # Setup database
     builder_echo "Setting up DB container"
-    docker run --rm -d -p 8099:1433 \
+    docker run --rm -d -p 8059:1433 \
       -e "ACCEPT_EULA=Y" \
       -e "MSSQL_AGENT_ENABLED=true" \
       -e "MSSQL_SA_PASSWORD=yourStrong(\!)Password" \
@@ -123,7 +123,7 @@ if builder_start_action start:app; then
     db_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${DOCKER_IMAGE[db]})
 
     builder_echo "Spooling up site container"
-    docker run --rm -d -p 8098:80 -v ${SITE_HTML} \
+    docker run --rm -d -p 8058:80 -v ${SITE_HTML} \
       -e 'api_keyman_com_mssql_pw=yourStrong(\!)Password' \
       -e api_keyman_com_mssql_user=sa \
       -e 'api_keyman_com_mssqlconninfo=sqlsrv:Server='$db_ip',1433;TrustServerCertificate=true;Encrypt=false;Database=' \

--- a/schemas/model_info.source/1.0.1/model_info.source.json
+++ b/schemas/model_info.source/1.0.1/model_info.source.json
@@ -23,7 +23,7 @@
         "packageIncludes": { "type": "array", "items": { "type": "string", "enum": ["fonts"] }, "additionalItems": false },
         "version": { "type": "string" },
         "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.0$" },
-        "helpLink": { "type": "string", "pattern": "^http(s)?://help\\.keyman(-staging)?\\.com(.local)?/lexical-model/" },
+        "helpLink": { "type": "string", "pattern": "^http(s)?://help\\.keyman(-staging)?\\.com(.localhost)?/lexical-model/" },
         "sourcePath": { "type": "string", "pattern": "^(release|experimental)/.+/.+$" },
         "related": { "type": "object", "patternProperties": {
           ".": { "$ref": "#/definitions/ModelRelatedInfo" }

--- a/tests/ModelSearchTest.php
+++ b/tests/ModelSearchTest.php
@@ -20,7 +20,7 @@ final class ModelSearchTest extends TestCase
 
   public function testSimpleResultValidatesAgainstSchema(): void
   {
-    //http://api.keyman.com.local/model?q=sil
+    //http://api.keyman.com.localhost/model?q=sil
     $schema = TestUtils::LoadJSONSchema(ModelSearchTest::SchemaFilename);
     $mssql = \Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -20,7 +20,7 @@ final class ModelTest extends TestCase
 
   public function testSimpleResultValidatesAgainstSchema(): void
   {
-    //http://api.keyman.com.local/model/gff.am.gff_amharic
+    //http://api.keyman.com.localhost/model/gff.am.gff_amharic
     $schema = TestUtils::LoadJSONSchema(ModelTest::SchemaFilename);
     $mssql = \Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
 

--- a/tests/manual/validate-kmw-api-transition.php
+++ b/tests/manual/validate-kmw-api-transition.php
@@ -6,7 +6,7 @@
   
   if(sizeof($params) > 0 && ($params[0] == '-l' || $params[0] == '--local')) {
     array_shift($params);
-    $api_root = "http://api.keyman.com.local";
+    $api_root = "http://api.keyman.com.localhost";
   } else {
     $api_root = "https://api.keyman.com";
   }


### PR DESCRIPTION
This updates follows the latest guidance to use .localhost instead of .local on Devs' locally hosted sites

Mirrors keymanapp/help.keyman.com#801