### PR TITLE
fix: error when submitting diagnostic report

### DIFF
--- a/script/desktop/10.0/submitdiag/index.php
+++ b/script/desktop/10.0/submitdiag/index.php
@@ -70,7 +70,7 @@
   $data = [
     "title" => "Diagnostic Report from ".$username,
     "raw" => "$Title\n\n$Body\n\nDiagnostic: $upload_url\n",
-    "target_usernames" => "keyman-diagnostics",
+    "target_recipients" => "keyman-diagnostics",
     "archetype" => "private_message"
   ];
 


### PR DESCRIPTION
Fixes #214.

Discourse API changed at some point so submitting a post would fail with a 422 error due to a change in a field name.

https://meta.discourse.org/t/unable-to-send-a-pm-via-discourseapi-errors-you-must-select-a-valid-user/282943

Ref: https://github.com/discourse/discourse/pull/22561 apparently marked for removal in v2.9.0.