### PR TITLE
fix: Pin sha of server:2022-latest 🦭

### DIFF
--- a/mssql.Dockerfile
+++ b/mssql.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/mssql/server:2022-latest
+FROM mcr.microsoft.com/mssql/server:2022-latest@sha256:3adc70cba564b18190340eb4b82d11dd1c99dbca5fc490b20290f8f6a138069f
 USER root
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/mssql.Dockerfile
+++ b/mssql.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/mssql/server:2022-latest@sha256:3adc70cba564b18190340eb4b82d11dd1c99dbca5fc490b20290f8f6a138069f
+FROM mcr.microsoft.com/mssql/server:2022-latest@sha256:ffef32dda16cc5abd70db1d0654c01cbe9f7093d66e0c83ade20738156cb7d0e
 USER root
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
@@ -7,7 +7,7 @@ apt-get update --fix-missing && \
 apt-get install -y gnupg2 && \
 apt-get install -yq curl apt-transport-https && \
 curl https://packages.microsoft.com/keys/microsoft.asc | tac | tac | apt-key add - && \
-curl https://packages.microsoft.com/config/ubuntu/20.04/mssql-server-2019.list | tac | tac | tee /etc/apt/sources.list.d/mssql-server.list && \
+curl https://packages.microsoft.com/config/ubuntu/22.04/mssql-server-2022.list | tac | tac | tee /etc/apt/sources.list.d/mssql-server.list && \
 apt-get update
 
 RUN apt-get install -y mssql-server-fts


### PR DESCRIPTION
Recently, my local `./build.sh build` started failing when attempting to install `mssql-server-fts`  due to broken/held package of libldap.

The history on https://hub.docker.com/_/microsoft-mssql-server shows 2022-latest got updated 11/16/2023.

Going to see if pinning the SHA (from the latest GHA) works for me.

-------------

Update:
Pulling a newer sha for 2022-latest and updating the Microsoft packages might be working...

Replacing https://packages.microsoft.com/config/ubuntu/20.04/mssql-server-2019.list 
with https://packages.microsoft.com/config/ubuntu/22.04/mssql-server-2022.list