### PR TITLE
fix: Pin sha of php:7.4-apache 🦭

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM php:7.4-apache AS composer-builder
+FROM php:7.4-apache@sha256:c9d7e608f73832673479770d66aacc8100011ec751d1905ff63fae3fe2e0ca6d AS composer-builder
 
 # Install Zip to use composer
 RUN apt-get update && apt-get install -y \
@@ -18,7 +18,7 @@ COPY composer.* /composer/
 RUN composer install
 
 # Site
-FROM php:7.4-apache
+FROM php:7.4-apache@sha256:c9d7e608f73832673479770d66aacc8100011ec751d1905ff63fae3fe2e0ca6d
 COPY resources/keyman-site.conf /etc/apache2/conf-available/
 RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 RUN echo memory_limit = 1024M >> /usr/local/etc/php/php.ini


### PR DESCRIPTION
Follow-up to #217 
This pins the sha of the Docker image for php:7.4-apache.

Relates to keymanapp/keyman.com#403