### PR TITLE
fix: _control/ready

### DIFF
--- a/_control/ready.php
+++ b/_control/ready.php
@@ -1,8 +1,11 @@
 <?php
   header("Content-Type: text/plain");
 
-  // Test db connection. Connect fails if db is not ready
   require_once(__DIR__ . '/../tools/db/db.php');
+
+  // Test web server ready, and _common files, and vendor files ready
+
+  // Test db connection. Connect fails if db is not ready
   $mssql = Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
 
   // Test db is built
@@ -15,15 +18,37 @@
     if ($stmt->execute()) {
       $data = $stmt->fetchAll(PDO::FETCH_NUM);
       //json_print($data);
-    };
+    }
   } catch(PDOException $e) {
     die('Error: ' . $e->getMessage());
   }
 
-  // Test web server ready, and _common files, and vendor files ready
-  if (!file_exists(__DIR__ . '/../tools/db/build/cjk/chinese_pinyin_import.sql') &&
-      !file_exists(__DIR__ . '/../tools/db/build/cjk/japanese_import.sql')) {    
-    die('/tools/db/build/cjk/*_import.sql not ready');
+  // Test chinese_pinyin_import.sql ready with query
+  $stmt = $mssql->prepare(
+    'SELECT pinyin_key, chinese_text, tip FROM kmw_chinese_pinyin WHERE pinyin_key=? ORDER BY frequency DESC, id');
+  $py = 'biguansuoguo';
+  $stmt->bindParam(1, $py);
+  try {
+    if ($stmt->execute()) {
+      $data = $stmt->fetchAll(PDO::FETCH_NUM);
+      //json_print($data);
+    }
+  } catch(PDOException $e) {
+    die('chinese_pinyin_import.sql not ready: ' . $e->getMessage());
+  }
+
+  // Test japanese_import.sql ready with query
+  $stmt = $mssql->prepare(
+    'SELECT DISTINCT kanji, gloss, pri FROM kmw_japanese WHERE (kana=?) ORDER BY pri');
+  $kana = 'あいでし';
+  $stmt->bindParam(1, $kana);
+  try {
+    if ($stmt->execute()) {
+      $data = $stmt->fetchAll(PDO::FETCH_NUM);
+      //json_print($data);
+    }
+  } catch(PDOException $e) {
+    die('japanese_import.sql not ready: ' . $e->getMessage());
   }
 
   if (!file_exists(__DIR__ . '/../tools/db/activeschema.txt')) {


### PR DESCRIPTION
Follows #223 

/_control/ready passes locally on DEVELOPMENT tier, but at the moment, 
https://api.keyman-staging.com/_control/ready

has an error:
> /tools/db/build/cjk/*_import.sql not ready

I think there's some subtle differences between the DEVELOPMENT tier and STAGING tier deployment where the files reside on different containers. (db vs app).

This revises the ready check to use additional db queries to check if it's ready.

I don't know if the check for `tools/db/activeschema.txt` needs to be adjusted too. The info is available on /_control/info.php
and I wonder if this would be adding too much:
`require_once __DIR__ . '/../tools/db/servervars.php';`




