### PR TITLE
fix: reduce query string length for full text searches

### DIFF
--- a/script/search/2.0/search.inc.php
+++ b/script/search/2.0/search.inc.php
@@ -62,7 +62,7 @@
         $result->platform = 'web';
       }
 
-      $query = trim($query);
+      $query = $this->CleanQueryString(trim($query));
 
       if(preg_match('/^('.implode('|',array_keys(KeyboardSearch::FILTERS)).')(.+)$/', $query, $matches)) {
         $result->text = $matches[2];
@@ -125,7 +125,7 @@
       } else {
         $r = "";
       }
-      return $r;
+      return substr($r, 0, 63);
     }
 
     function QueryStringToIdSearch($text) {
@@ -139,7 +139,7 @@
     private function GetSearchQueries(KeyboardSearchResult $result) {
       $result->totalRows = 0;
       $clampTotalRows = 0;
-      $text = $this->CleanQueryString($result->text);
+      $text = $result->text;
       $idtext = $this->QueryStringToIdSearch($text);
 
       switch($result->filter) {

--- a/script/search/2.0/search.inc.php
+++ b/script/search/2.0/search.inc.php
@@ -62,7 +62,7 @@
         $result->platform = 'web';
       }
 
-      $query = $this->CleanQueryString(trim($query));
+      $query = substr(trim($query), 0, 63);
 
       if(preg_match('/^('.implode('|',array_keys(KeyboardSearch::FILTERS)).')(.+)$/', $query, $matches)) {
         $result->text = $matches[2];
@@ -139,7 +139,7 @@
     private function GetSearchQueries(KeyboardSearchResult $result) {
       $result->totalRows = 0;
       $clampTotalRows = 0;
-      $text = $result->text;
+      $text = $this->CleanQueryString($result->text);
       $idtext = $this->QueryStringToIdSearch($text);
 
       switch($result->filter) {


### PR DESCRIPTION
Moves the filtering earlier in order to get the benefit in the returned object as well as in what we pass to the database.

Fixes: #251
Fixes: API-KEYMAN-COM-1