### PR TITLE
fix(windows): track discourse field name change for upload.json

### DIFF
--- a/script/desktop/10.0/submitdiag/index.php
+++ b/script/desktop/10.0/submitdiag/index.php
@@ -52,7 +52,7 @@
   }
 
   $data = [
-    "type" => "composer",
+    "upload_type" => "composer",
     "username" => $username,
     "files[]" => new cURLFile($DataFilename, 'application/octet-stream', $Filename),
     "synchronous" => 'true'


### PR DESCRIPTION
Discourse API changed with a recent update to community.software.sil.org.

Fixes: keymanapp/keyman#12678