### PR TITLE
refactor: clean up KeymanHosts usage and make consistent

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=v0.11
+readonly BOOTSTRAP_VERSION=fix/keyman-hosts-for-server  # v0.11
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=fix/keyman-hosts-for-server  # v0.11
+readonly BOOTSTRAP_VERSION=v0.17
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/tools/2020/DownloadsApi.php
+++ b/tools/2020/DownloadsApi.php
@@ -23,7 +23,7 @@
     }
 
     protected function GetData($path) {
-      return @file_get_contents(KeymanHosts::Instance()->downloads_keyman_com . "/api" . $path);
+      return @file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . "/api" . $path);
     }
 
     public function GetPlatformVersion($platform) {

--- a/tools/2020/SKeymanComApi.php
+++ b/tools/2020/SKeymanComApi.php
@@ -23,7 +23,7 @@
     }
 
     protected function GetData($path) {
-      return @file_get_contents(KeymanHosts::Instance()->s_keyman_com . "/api" . $path);
+      return @file_get_contents(KeymanHosts::Instance()->SERVER_s_keyman_com . "/api" . $path);
     }
 
     public function GetKmwVersion() {

--- a/tools/onlineupdate.php
+++ b/tools/onlineupdate.php
@@ -130,7 +130,7 @@
 
     private function BuildKeyboardResponse($id, $version, $appVersion) {
       $platform = $this->platform;
-      $KeyboardDownload = @file_get_contents(KeymanHosts::Instance()->api_keyman_com."/keyboard/$id");
+      $KeyboardDownload = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com."/keyboard/$id");
       if($KeyboardDownload === FALSE) {
         // not found
         return FALSE;
@@ -188,7 +188,7 @@
 
     private function BuildKeyboardDownloadPath($id, $version) {
       // TODO: use DownloadsApi
-      $data = @file_get_contents(KeymanHosts::Instance()->downloads_keyman_com . "/api/keyboard/$id");
+      $data = @file_get_contents(KeymanHosts::Instance()->SERVER_downloads_keyman_com . "/api/keyboard/$id");
       if($data === FALSE) {
         return FALSE;
       }


### PR DESCRIPTION
* Splits the server-side and client-side references to keyman sites so that docker-based PHP can reference host.docker.internal on development machines for cross-references.

* Removes some links to legacy sites such as sentry.keyman.com.

- [x] TODO: update to `BOOTSTRAP_VERSION=v0.17` in build.sh before merge.

Relates-to: keymanapp/shared-sites#53
Relates-to: keymanapp/keyman.com#545