### PR TITLE
chore: restrict empty search query

### DIFF
--- a/script/search/1.0/search.php
+++ b/script/search/1.0/search.php
@@ -36,7 +36,11 @@
     fail('Query string must be set');
   }
 
-  $q = $_REQUEST['q'];
+  $q = trim($_REQUEST['q']);
+
+  if($q == '') {
+    fail('Query string must not be empty');
+  }
 
   $s = new KeyboardSearch($mssql);
   if(isset($_REQUEST['platform'])) {

--- a/script/search/2.0/search.php
+++ b/script/search/2.0/search.php
@@ -42,7 +42,12 @@
   header('Link: <' . KeymanHosts::Instance()->api_keyman_com . '/schemas/search/2.0/search.json#>; rel="describedby"');
   //header('') TODO: add page information to results
 
-  $query = $_REQUEST['q'];
+  $query = trim($_REQUEST['q']);
+
+  if($query == '') {
+    fail('Query string must not be empty');
+  }
+
   $platform = isset($_REQUEST['platform']) ? $_REQUEST['platform'] : null;
   $obsolete = !empty($_REQUEST['obsolete']);
 


### PR DESCRIPTION
An empty search query is expensive and should not be permitted, as it returns every record in the keyboard table, rather than a subset.

Note: this is a mitigation, as no rate limiting is supported. v2.0 search supports paging, so perhaps we should consider retiring v1.0 search altogether.