### PR TITLE
fix: provide repair version of keyman-18.0.240.exe for 18.0.235-236 version users

### DIFF
--- a/script/windows/14.0/update/WindowsUpdateCheck.php
+++ b/script/windows/14.0/update/WindowsUpdateCheck.php
@@ -43,8 +43,9 @@
 
       return json_encode($desktop_update, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
-    // This is function is added to repair an issue where Keyman windows would not upgrade
-    // to a newer version correctly see the issues below.
+    // RepairVersionCheck works around an issue where Keyman for Windows 18.0.235-236 
+    // would not upgrade to a newer version; see the links below for more details.
+    // https://downloads.keyman.com/windows/stable/18.0.240/repair-14586/README.md
     // https://github.com/keymanapp/keyman/issues/13831
     // https://github.com/keymanapp/keyman/pull/13867
     // https://github.com/keymanapp/keyman/pull/14010


### PR DESCRIPTION
Fixes: #293
Ref:
* keymanapp/keyman#14586

# User Testing

@mcdurdin  I think the test you did can be a test for this api side change. As such I did not right every detailed step as you have already carried out this test. 

## TEST_local_host

- Setup api.keyman.com running as a local host with this PR change running.
- Install Keyman for Windows 18.0.235 or 18.0.236
- Change the api.keyman.com host using the advanced developer settings to local host
- Check for updates on the Update tab.
- Verify that `C:\Users\{UserName}\AppData\Local\Keyman\UpdateCache` contains keyman `keyman-18.0.000.exe` once downloaded. 
- Then either restart or press install now and choose 'update' and Yes to elevation prompt.

Once installed verify the new version is 18.0.240