### PR TITLE
chore: update mssql-2022 to 6249e946 image

### DIFF
--- a/mssql.Dockerfile
+++ b/mssql.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/mssql/server:2022-latest@sha256:d252932ef839c24c61c1139cc98f69c85ca774fa7c6bfaaa0015b7eb02b9dc87 
+FROM mcr.microsoft.com/mssql/server:2022-latest@sha256:6249e946034c0b72e98cbbdd790deede2bb94fe5c73335ecdbb77176af4d267c
 USER root
 
 RUN export DEBIAN_FRONTEND=noninteractive && \


### PR DESCRIPTION
This seemed to fix the error "Could not allocate initial 5000 lock owner blocks during startup." on my machine. I was unable to locate a specific fix relating to the problem, but SQL Server is starting now. Will monitor in case the issue recurs.

Test-bot: skip