### PR TITLE
chore: use a broader query for stats and just return everything

### DIFF
--- a/script/statistics/annual-statistics.inc.php
+++ b/script/statistics/annual-statistics.inc.php
@@ -21,8 +21,8 @@ class AnnualStatistics {
     $stmt->bindParam(":prmEndDate", $endDate);
 
     $stmt->execute();
-    $data = $stmt->fetchAll()[0];
-    $data = array_filter($data, "Keyman\\Site\\com\\keyman\\api\\filter_columns_by_name", ARRAY_FILTER_USE_KEY );
+    $data = $stmt->fetchAll();
+    // $data = array_filter($data, "Keyman\\Site\\com\\keyman\\api\\filter_columns_by_name", ARRAY_FILTER_USE_KEY );
     return $data;
   }
 }


### PR DESCRIPTION
Stats was returning a malformed result because of assumptions about the shape of the result. Instead, return all the data and leave interpretation up to user. This is okay because it's an internal-use-only script at present.

Test-bot: skip