### PR TITLE
docs: add .model_info 2.0 schema

### DIFF
--- a/schemas/.htaccess
+++ b/schemas/.htaccess
@@ -2,23 +2,34 @@
 # versioned schema files rather than to the base, so we will not add extra
 # redirects here for new schemas
 
+
+# keyboard_info.schema.json (deprecates keyboard_info.source.json, keyboard_info.distribution.json)
+RewriteRule "^keyboard_info\.schema\.json$" "/schemas/keyboard_info/2.0/keyboard_info.schema.json" [END]
+
 # keyboard_info.distribution.json (deprecated by keyboard_info.schema.json)
 RewriteRule "^keyboard_info\.distribution\.json$" "/schemas/keyboard_info.distribution/1.0.6/keyboard_info.distribution.json" [END]
 
 # keyboard_info.source.json (deprecated by keyboard_info.schema.json)
 RewriteRule "^keyboard_info\.source\.json$" "/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json" [END]
 
+
 # keyboard_json.json
 RewriteRule "^keyboard_json\.json$" "/schemas/keyboard_json/1.0/keyboard_json.json" [END]
 
-# model_info.distribution.json"
+
+# model_info.schema.json (deprecates model_info.source.json, model_info.distribution.json)
+RewriteRule "^model_info\.schema\.json$" "/schemas/model_info/2.0/model_info.schema.json" [END]
+
+# model_info.distribution.json" (deprecated by model_info.schema.json)
 RewriteRule "^model_info\.distribution\.json$" "/schemas/model_info.distribution/1.0.1/model_info.distribution.json" [END]
 
-# model_info.source.json
+# model_info.source.json (deprecated by model_info.schema.json)
 RewriteRule "^model_info\.source\.json$" "/schemas/model_info.source/1.0.1/model_info.source.json" [END]
+
 
 # model-search.json
 RewriteRule "^model-search\.json$" "/schemas/model-search/1.0.1/model-search.json" [END]
+
 
 # package.json (renamed to kmp.schema.json)
 
@@ -31,14 +42,18 @@ RewriteRule "^package/1\.0\.1/package\.json$" "/schemas/kmp/1.0.1/kmp.schema.jso
 RewriteRule "^package/1\.0\.2/package\.json$" "/schemas/kmp/1.0.2/kmp.schema.json" [END]
 RewriteRule "^package/1\.1\.0/package\.json$" "/schemas/kmp/1.1.0/kmp.schema.json" [END]
 
+
 # package-version.json
 RewriteRule "^package-version\.json$" "/schemas/package-version/1.0.1/package-version.json" [END]
+
 
 # search.json
 RewriteRule "^search\.json$" "/schemas/search/3.0/search.json" [END]
 
+
 # version.json
 RewriteRule "^version\.json$" "/schemas/version/2.0/version.json" [END]
+
 
 # windows-update.json
 RewriteRule "^windows-update\.json$" "/schemas/windows-update/17.0/windows-update.json" [END]

--- a/schemas/model_info.distribution/README.md
+++ b/schemas/model_info.distribution/README.md
@@ -1,12 +1,14 @@
 # model_info
 
+Deprecated: see [model_info/README.md](../model_info/README.md)
+
 * model_info.source.json
 * model_info.distribution.json
 
 Documentation at https://help.keyman.com/developer/cloud/model_info
 
-## 2019-01-31 1.0 beta
-* Initial version, seeded from .keyboard_info specification
-
 ## 2020-09-21 1.0.1
 * Relaxed the URL definitions in the schema so extension is no longer tested
+
+## 2019-01-31 1.0 beta
+* Initial version, seeded from .keyboard_info specification

--- a/schemas/model_info.source/README.md
+++ b/schemas/model_info.source/README.md
@@ -1,12 +1,14 @@
 # model_info
 
+Deprecated: see [model_info/README.md](../model_info/README.md)
+
 * model_info.source.json
 * model_info.distribution.json
 
 Documentation at https://help.keyman.com/developer/cloud/model_info
 
-## 2019-01-31 1.0 beta
-* Initial version, seeded from .keyboard_info specification
-
 ## 2020-09-21 1.0.1
 * Relaxed the URL definitions in the schema so extension is no longer tested
+
+## 2019-01-31 1.0 beta
+* Initial version, seeded from .keyboard_info specification

--- a/schemas/model_info/2.0/model_info.schema.json
+++ b/schemas/model_info/2.0/model_info.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$ref": "#/definitions/ModelInfo",
+
+  "definitions": {
+    "ModelInfo": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "authorName": { "type": "string" },
+        "authorEmail": { "type": "string", "format": "email" },
+        "description": { "type": "string" },
+        "license": { "type": "string", "enum": ["mit"] },
+        "languages": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "lastModifiedDate": { "type": "string", "format": "date-time" },
+        "packageFilename": { "type": "string" },
+        "packageFileSize": { "type": "number" },
+        "jsFilename": { "type": "string" },
+        "jsFileSize": { "type": "number" },
+        "isRTL": { "type": "boolean" },
+        "packageIncludes": { "type": "array", "items": { "type": "string", "enum": ["fonts"] }, "additionalItems": false },
+        "version": { "type": "string" },
+        "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.0$" },
+        "helpLink": { "type": "string", "pattern": "^http(s)?://help\\.keyman(-staging)?\\.com(.localhost)?/model/" },
+        "sourcePath": { "type": "string", "pattern": "^(release|experimental)/.+/.+$" },
+        "related": { "type": "object", "patternProperties": {
+          ".": { "$ref": "#/definitions/ModelRelatedInfo" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "license", "languages"
+      ],
+      "additionalProperties": false
+    },
+
+    "ModelRelatedInfo": {
+      "type": "object",
+      "properties": {
+        "deprecates": { "type": "boolean" },
+        "deprecatedBy": { "type": "boolean" }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/model_info/README.md
+++ b/schemas/model_info/README.md
@@ -1,0 +1,25 @@
+# model_info
+
+* **model_info.schema.json**
+
+Documentation at https://help.keyman.com/developer/cloud/model_info
+
+* Primary version:
+  * https://github.com/keymanapp/api.keyman.com/tree/master/schemas/model_info
+* Synchronized copies at:
+  * https://github.com/keymanapp/keyman/tree/master/common/schemas/model_info
+
+# .model_info version history
+
+## 2023-08-11 2.0 stable
+* Removed:
+    `.links`
+    `.related[].note`
+  - Source .model_info files are no longer needed, so source vs distribution
+    model_info distinction is removed
+
+## 2020-09-21 1.0.1
+* Relaxed the URL definitions in the schema so extension is no longer tested
+
+## 2019-01-31 1.0 beta
+* Initial version, seeded from .keyboard_info specification


### PR DESCRIPTION
Adds the .model_info 2.0 schema, deprecates the .source and .distribution versions, and also fixes broken redirect for .keyboard_info.schema.json.

Relates-to: keymanapp/keyman#14967
Relates-to: keymanapp/help.keyman.com#2300
Test-bot: skip