### PR TITLE
fix: select existing tag name in langtag canonicalization

### DIFF
--- a/tools/db/build/search-prepare-data-4.sql
+++ b/tools/db/build/search-prepare-data-4.sql
@@ -14,7 +14,7 @@ SELECT DISTINCT
   null,
   t.region,
   t.regionname,
-  kl.description,
+  t.name,
   0,
   kl.script_id,
   kl.bcp47


### PR DESCRIPTION
Problem description in #312; this fix just uses the existing langtags name rather than the name from the .keyboard_info, which could vary. The name is used only as a display name, not a search name, so no searching will be impacted. It is possible that a different name may be selected as representative, but that is probably better because we should be using langtags.json for language names in most contexts anyway.

Fixes: #312
Test-bot: skip