### PR TITLE
fix: report all columns from annual stats as JSON

### DIFF
--- a/script/statistics/annual.php
+++ b/script/statistics/annual.php
@@ -29,9 +29,4 @@
 
   $stats = new \Keyman\Site\com\keyman\api\AnnualStatistics();
   $data = $stats->execute($mssql, $startDate, $endDate);
-  $rows = [];
-  foreach($data as $row) {
-    $rows[$row[0]] = ["Value" => $row[2], "Comment" => $row[1]];
-  }
-
-  json_print($rows);
+  json_print($data);


### PR DESCRIPTION
The previous report was only showing the first column, incorrectly. For now, just report all columns as JSON, and in future we'll add more formatting as we work on analytics.

Test-bot: skip