### PR TITLE
feat: add keyboard download stats by period

### DIFF
--- a/script/statistics/annual-statistics.inc.php
+++ b/script/statistics/annual-statistics.inc.php
@@ -7,44 +7,44 @@
 
   namespace Keyman\Site\com\keyman\api;
 
+class AnnualStatistics {
+
+  function execute($mssql, $startDate, $endDate) {
+    return $this->_execute('sp_annual_statistics', $mssql, $startDate, $endDate);
+  }
+
+  function executeDownloadsByMonth($mssql, $startDate, $endDate) {
+    return $this->_execute('sp_keyboard_downloads_by_month_statistics', $mssql, $startDate, $endDate);
+  }
+
+  function executeKeyboards($mssql, $startDate, $endDate) {
+    return $this->_execute('sp_statistics_keyboard_downloads_by_id', $mssql, $startDate, $endDate);
+  }
+
+  private function _execute($proc, $mssql, $startDate, $endDate) {
+    $stmt = $mssql->prepare("EXEC $proc :prmStartDate, :prmEndDate");
+
+    $stmt->bindParam(":prmStartDate", $startDate);
+    $stmt->bindParam(":prmEndDate", $endDate);
+
+    $stmt->execute();
+    $data = $stmt->fetchAll();
+    return $this->filter_columns_by_name($data);
+  }
+
   // strip out repeated columns with numeric keys (by default the results returned
   // give each column twice, once with a column name, and once with a column index)
-  function filter_columns_by_name($data) {
+  private function filter_columns_by_name($data) {
     $result = [];
     foreach($data as $row) {
       $r = [];
       foreach($row as $id => $val) {
         if(!is_numeric($id)) {
-          $r[$id] = intval($val);
+          $r[$id] = is_numeric($val) ? intval($val) : $val;
         }
       }
       array_push($result, $r);
     }
     return $result;
-  }
-
-class AnnualStatistics {
-
-  function execute($mssql, $startDate, $endDate) {
-
-    $stmt = $mssql->prepare('EXEC sp_annual_statistics :prmStartDate, :prmEndDate');
-
-    $stmt->bindParam(":prmStartDate", $startDate);
-    $stmt->bindParam(":prmEndDate", $endDate);
-
-    $stmt->execute();
-    $data = $stmt->fetchAll();
-    return filter_columns_by_name($data);
-  }
-
-  function executeDownloadsByMonth($mssql, $startDate, $endDate) {
-    $stmt = $mssql->prepare('EXEC sp_keyboard_downloads_by_month_statistics :prmStartDate, :prmEndDate');
-
-    $stmt->bindParam(":prmStartDate", $startDate);
-    $stmt->bindParam(":prmEndDate", $endDate);
-
-    $stmt->execute();
-    $data = $stmt->fetchAll();
-    return filter_columns_by_name($data);
   }
 }

--- a/script/statistics/keyboards.php
+++ b/script/statistics/keyboards.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Basic keyboard download statistics for SIL reports
+ */
+
+  require_once(__DIR__ . '/../../tools/util.php');
+
+  allow_cors();
+  json_response();
+
+  require_once(__DIR__ . '/../../tools/db/db.php');
+  require_once(__DIR__ . '/annual-statistics.inc.php');
+  require_once __DIR__ . '/../../tools/autoload.php';
+  use Keyman\Site\Common\KeymanHosts;
+  $mssql = Keyman\Site\com\keyman\api\Tools\DB\DBConnect::Connect();
+
+  if(!isset($_REQUEST['startDate']) || !isset($_REQUEST['endDate'])) {
+    fail('startDate, endDate parameters must be set');
+  }
+
+  $startDate = $_REQUEST['startDate'];
+  $endDate = $_REQUEST['endDate'];
+
+  /**
+   * https://api.keyman.com/script/statistics/keyboards.php
+   */
+
+  $stats = new \Keyman\Site\com\keyman\api\AnnualStatistics();
+  $keyboards = $stats->executeKeyboards($mssql, $startDate, $endDate);
+
+  if(isset($_REQUEST['csv'])) {
+    $out = fopen('php://output', 'w');
+
+    if(sizeof($keyboards) > 0) {
+      $data = array_keys($keyboards[0]);
+      fputcsv($out, $data, ',', '"', '');
+      foreach($keyboards as $row) {
+        $data = array_values($row);
+        fputcsv($out, $data, ',', '"', '');
+      }
+    }
+
+    fclose($out);
+  } else {
+    $data = ["keyboards" => $keyboards];
+    json_print($data);
+  }


### PR DESCRIPTION
Returns list of keyboard id and name, with keyboard download count and daily average, in JSON or CSV format

Usage:
* JSON: /script/statistics/keyboards.php?startDate=2025-01-01&endDate=2026-01-01
* CSV: /script/statistics/keyboards.php?startDate=2025-01-01&endDate=2026-01-01&csv=1

Test-bot: skip