### PR TITLE
feat: use app go/ url for online update checks to capture download stats

### DIFF
--- a/schemas/windows-update/17.0/sample.json
+++ b/schemas/windows-update/17.0/sample.json
@@ -1,0 +1,178 @@
+{
+    "msi": {
+        "name": "Keyman for Windows MSI installer",
+        "version": "18.0.245",
+        "date": "2025-12-03",
+        "platform": "win",
+        "stability": "stable",
+        "file": "keymandesktop.msi",
+        "md5": "98EABC9C8F4803B11C5EF2EF64F0D802",
+        "type": "msi",
+        "build": "245",
+        "size": 110870528,
+        "url": "https://downloads.keyman.com/windows/stable/18.0.245/keymandesktop.msi"
+    },
+    "setup": {
+        "name": "Keyman for Windows setup bootstrap",
+        "version": "18.0.245",
+        "date": "2025-12-03",
+        "platform": "win",
+        "stability": "stable",
+        "file": "setup.exe",
+        "md5": "C32FD8926909F1E447BBC72AF8B16380",
+        "type": "exe",
+        "build": "245",
+        "size": 4032904,
+        "url": "https://downloads.keyman.com/windows/stable/18.0.245/setup.exe"
+    },
+    "bundle": {
+        "name": "Keyman for Windows",
+        "version": "18.0.245",
+        "date": "2025-12-03",
+        "platform": "win",
+        "stability": "stable",
+        "file": "keyman-18.0.245.exe",
+        "md5": "2BE0290AF6DF49BA736CEDCE50D1E763",
+        "type": "exe",
+        "build": "245",
+        "size": 111668424,
+        "url": "https://downloads.keyman.com/windows/stable/18.0.245/keyman-18.0.245.exe"
+    },
+    "keyboards": {
+        "khmer_angkor": {
+            "id": "khmer_angkor",
+            "name": "Khmer Angkor",
+            "license": "mit",
+            "authorName": "Makara Sok",
+            "authorEmail": "makara_sok@sil.org",
+            "description": "<p>Khmer Unicode keyboard layout based on the NiDA keyboard layout.\nAutomatically corrects many common keying errors.</p>",
+            "languages": {
+                "km": {
+                    "examples": [
+                        {
+                            "keys": "x j m E r",
+                            "note": "Name of language",
+                            "text": "\u1781\u17d2\u1798\u17c2\u179a"
+                        }
+                    ],
+                    "font": {
+                        "family": "Busra",
+                        "source": [
+                            "Busra-Regular.ttf"
+                        ]
+                    },
+                    "oskFont": {
+                        "family": "KbdKhmr",
+                        "source": [
+                            "KbdKhmr.ttf"
+                        ]
+                    },
+                    "languageName": "Khmer",
+                    "displayName": "Khmer"
+                }
+            },
+            "lastModifiedDate": "2025-12-16T08:51:56.000Z",
+            "packageFilename": "khmer_angkor.kmp",
+            "packageFileSize": 2541924,
+            "jsFilename": "khmer_angkor.js",
+            "jsFileSize": 74154,
+            "packageIncludes": [
+                "visualKeyboard",
+                "welcome",
+                "documentation",
+                "fonts"
+            ],
+            "version": "2.4",
+            "encodings": [
+                "unicode"
+            ],
+            "platformSupport": {
+                "windows": "full",
+                "macos": "full",
+                "linux": "full",
+                "desktopWeb": "full",
+                "ios": "full",
+                "android": "full",
+                "mobileWeb": "full"
+            },
+            "minKeymanVersion": "10.0",
+            "sourcePath": "release/k/khmer_angkor",
+            "helpLink": "https://help.keyman.com/keyboard/khmer_angkor",
+            "related": {
+                "khmer10": {
+                    "deprecates": true
+                },
+                "basic_kbdkni": {
+                    "deprecates": false
+                }
+            },
+            "url": "https://keyman.com/go/package/download/khmer_angkor?version=2.4&platform=windows&tier=stable&update=0"
+        },
+        "sil_ipa": {
+            "id": "sil_ipa",
+            "name": "IPA (SIL)",
+            "license": "mit",
+            "authorName": "Martin Hosken, Lorna Evans",
+            "authorEmail": "fonts@sil.org",
+            "description": "<p>The keyboard layout is described in terms of an IPA chart rather than a\nkeyboard. This is because many base characters are typed as a sequence\nof a letter followed by one of &lt;, &gt; or = which are characters used to\nchange a base character to another base character. Diacritics are typed\nas sequences of an appropriate key.</p>",
+            "languages": {
+                "und-latn": {
+                    "examples": [],
+                    "font": {
+                        "family": "Charis",
+                        "source": [
+                            "Charis-Regular.ttf"
+                        ]
+                    },
+                    "oskFont": {
+                        "family": "Charis",
+                        "source": [
+                            "Charis-Regular.ttf"
+                        ]
+                    },
+                    "languageName": "Undetermined",
+                    "scriptName": "Latin",
+                    "displayName": "Undetermined (Latin)"
+                }
+            },
+            "lastModifiedDate": "2025-06-09T21:19:30.000Z",
+            "packageFilename": "sil_ipa.kmp",
+            "packageFileSize": 3626354,
+            "jsFilename": "sil_ipa.js",
+            "jsFileSize": 88661,
+            "packageIncludes": [
+                "documentation",
+                "welcome",
+                "fonts"
+            ],
+            "version": "2.0.2",
+            "encodings": [
+                "unicode"
+            ],
+            "platformSupport": {
+                "windows": "full",
+                "macos": "full",
+                "linux": "full",
+                "desktopWeb": "full",
+                "ios": "full",
+                "android": "full",
+                "mobileWeb": "full"
+            },
+            "minKeymanVersion": "17.0",
+            "sourcePath": "release/sil/sil_ipa",
+            "helpLink": "https://help.keyman.com/keyboard/sil_ipa",
+            "related": {
+                "ipauni11": {
+                    "deprecates": true
+                },
+                "ipauni111": {
+                    "deprecates": true
+                },
+                "ipa93_km5": {
+                    "deprecates": false
+                }
+            },
+            "url": "https://keyman.com/go/package/download/sil_ipa?version=2.0.2&platform=windows&tier=stable&update=0"
+        }
+    }
+}

--- a/script/windows/14.0/update/WindowsUpdateCheck.php
+++ b/script/windows/14.0/update/WindowsUpdateCheck.php
@@ -133,7 +133,9 @@
             }
           }
 
-          $filedata->url = KeymanHosts::Instance()->downloads_keyman_com . "/windows/$tier/{$filedata->version}/{$file}";
+          $filedata->url =
+            KeymanHosts::Instance()->keyman_com . "/go/app/download/windows/{$filedata->version}/$tier?url=" .
+            rawurlencode(KeymanHosts::Instance()->downloads_keyman_com . "/windows/$tier/{$filedata->version}/{$file}");
           return $filedata;
         }
       }

--- a/script/windows/14.0/update/index.php
+++ b/script/windows/14.0/update/index.php
@@ -1,4 +1,32 @@
 <?php
+  /**
+   * https://api.keyman.com/windows/{majorVersion}/update?version={fullVersion}&package_{id}={packageVersion}...&update={update}&manual={manual}
+   *
+   * Parameters:
+   *  - `majorVersion` is the same as the Keyman release version, "14.0" or
+   *    later
+   *  - `fullVersion` is the currently installed version on the user's computer,
+   *    e.g. "18.0.240.0"
+   *  - `id` is package id, e.g. "khmer_angkor"; more than one package is
+   *    allowed
+   *  - `packageVersion` is the version of that package, e.g. "1.0"
+   *  - `update` should be 0 for a new install (from setup.exe), or 1 for an
+   *    update
+   *  - `manual` should be 0 for automatic update checks, 1 for new install
+   *    (from setup.exe), or where the user presses 'Check for Updates'
+   *
+   *  This returns a JSON object, following the schema at
+   *  /schemas/windows-update/17.0/windows-update.json See example at
+   *  /schemas/windows-update/17.0/sample.json
+   *
+   *  The value for `update` is included in the URL for keyboard package
+   *  download in the JSON, e.g.:
+   *
+   *  `https://keyman.com/go/package/download/sil_ipa?version=2.0.2&platform=windows&tier=stable&update=0`
+   *
+   *  This is so it can be passed into the increment-download API, to allow us
+   *  to track whether updates are from new installs or from existing users.
+   */
   require_once __DIR__ . '/../../../../tools/base.inc.php';
   require_once __DIR__ . '/../../../../tools/util.php';
   require_once __DIR__ . '/../../../../tools/db/db.php';

--- a/tests/fixtures/WindowsUpdateCheck.14.0.json
+++ b/tests/fixtures/WindowsUpdateCheck.14.0.json
@@ -10,7 +10,7 @@
         "type": "exe",
         "build": "102",
         "size": 68694016,
-        "url": "https://downloads.keyman.com/windows/alpha/14.0.102.0/keymandesktop.msi"
+        "url": "https://keyman-staging.com/go/app/download/windows/14.0.102.0/alpha?url=https%3A%2F%2Fdownloads.keyman.com%2Fwindows%2Falpha%2F14.0.102.0%2Fkeymandesktop.msi"
     },
     "setup": {
         "name": "Keyman Desktop setup bootstrap",
@@ -23,7 +23,7 @@
         "type": "exe",
         "build": "102",
         "size": 4705280,
-        "url": "https://downloads.keyman.com/windows/alpha/14.0.102.0/setup.exe"
+        "url": "https://keyman-staging.com/go/app/download/windows/14.0.102.0/alpha?url=https%3A%2F%2Fdownloads.keyman.com%2Fwindows%2Falpha%2F14.0.102.0%2Fsetup.exe"
     },
     "bundle": {
         "name": "Keyman Desktop",
@@ -36,7 +36,7 @@
         "type": "exe",
         "build": "102",
         "size": 70575440,
-        "url": "https://downloads.keyman.com/windows/alpha/14.0.102.0/keymandesktop-14.0.102.0.exe"
+        "url": "https://keyman-staging.com/go/app/download/windows/14.0.102.0/alpha?url=https%3A%2F%2Fdownloads.keyman.com%2Fwindows%2Falpha%2F14.0.102.0%2Fkeymandesktop-14.0.102.0.exe"
     },
     "keyboards": {
         "khmer_angkor": {


### PR DESCRIPTION
In the online update check response, wrap download.keyman.com urls in the keyman.com/go/app/download url forwarding pattern.

Also, added some basic docs and sample response

Test-bot: skip