### PR TITLE
maint: Update GHA to Node 24

### DIFF
--- a/.github/workflows/add-to-keyman-project.yml
+++ b/.github/workflows/add-to-keyman-project.yml
@@ -13,6 +13,7 @@ jobs:
     name: Add new issues and pull requests to project
     runs-on: ubuntu-latest
     steps:
+      # TODO: Update to Node 24 when actions/add-to-project#712 is resolved
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/keymanapp/projects/1

--- a/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
+++ b/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
@@ -15,7 +15,7 @@ jobs:
     permissions: write-all
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.5
+      uses: actions/checkout@v5.0.1
       with:
         sparse-checkout: |
           README.md

--- a/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
+++ b/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
@@ -15,7 +15,7 @@ jobs:
     permissions: write-all
     steps:
     - name: Checkout
-      uses: actions/checkout@v5.0.1
+      uses: actions/checkout@v6.0.2
       with:
         sparse-checkout: |
           README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5.0.1
 
     - name: Build the Docker image
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5.0.1
+      uses: actions/checkout@v6.0.2
 
     - name: Build the Docker image
       shell: bash

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5.0.1
+        uses: actions/checkout@v6.0.2
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5.0.1
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,8 @@ jobs:
     steps:
     - name: Update labels based on PR title
       id: labeler
-      uses: fuxingloh/multi-labeler@f5bd7323b53b0833c1e4ed8d7b797ae995ef75b4 # v2.0.1
+      # latest but up to Node 20
+      uses: fuxingloh/multi-labeler@b15a54460c38f54043fa75f7b08a0e2aa5b94b5b # v4.0.0
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         config-path: .github/multi-labeler.yml


### PR DESCRIPTION
Addresses keymanapp/keyman.com#682 for api.keyman.com

GitHub action updated to Node 24
* github/actions-checkout@v6.0.2

latest but still Node 20
* fuxingloh/multi-labeler@b15a54460c38f54043fa75f7b08a0e2aa5b94b5b # v4.0.0

Test-bot: skip
