### PR TITLE
fix(common): add missing `default` property to keyman-touch-layout.clean.spec.json

### DIFF
--- a/schemas/keyman-touch-layout/2.1.2/keyman-touch-layout.clean.spec.json
+++ b/schemas/keyman-touch-layout/2.1.2/keyman-touch-layout.clean.spec.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$ref": "#/definitions/touch-layout",
+  "$comment": "Version: 16.0",
+  "description": "A Keyman Touch Layout file, per version 16.0, clean spec, no legacy data or types",
+
+  "definitions": {
+    "touch-layout": {
+      "type": "object",
+      "properties": {
+        "tablet": { "$ref": "#/definitions/platform" },
+        "phone": { "$ref": "#/definitions/platform" },
+        "desktop": { "$ref": "#/definitions/platform" }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+
+    "platform": {
+      "type": "object",
+      "properties": {
+        "font": { "$ref": "#/definitions/font-spec" },
+        "fontsize": { "$ref": "#/definitions/fontsize-spec" },
+        "layer": { "$ref": "#/definitions/layers" },
+        "displayUnderlying": { "type": "boolean" },
+        "defaultHint": { "type": "string", "enum": ["none","dot","longpress","multitap","flick","flick-n","flick-ne","flick-e","flick-se","flick-s","flick-sw","flick-w","flick-nw"] }
+      },
+      "required": ["layer"],
+      "additionalProperties": false
+    },
+
+    "layers": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/layer" },
+      "minItems": 1
+    },
+
+    "layer": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/definitions/layer-id" },
+        "row": { "$ref": "#/definitions/rows" }
+      },
+      "required": ["id", "row"],
+      "additionalProperties": false
+    },
+
+    "layer-id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_-]+$"
+    },
+
+    "rows": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/row" },
+      "minItems": 1
+    },
+
+    "row": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/definitions/row-id" },
+        "key": { "$ref": "#/definitions/keys" }
+      },
+      "required": ["id", "key"],
+      "additionalProperties": false
+    },
+
+    "row-id": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+
+    "keys": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/key" },
+      "minItems": 1
+    },
+
+    "key": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/definitions/key-id" },
+        "text": { "type": "string" },
+        "layer": { "$ref": "#/definitions/layer-id" },
+        "nextlayer": { "$ref": "#/definitions/layer-id" },
+        "fontsize": { "$ref": "#/definitions/fontsize-spec" },
+        "font": { "$ref": "#/definitions/font-spec" },
+        "sp": { "$ref" : "#/definitions/key-sp" },
+        "pad": { "$ref" : "#/definitions/key-pad" },
+        "width": { "$ref" : "#/definitions/key-width" },
+        "sk": { "$ref": "#/definitions/subkeys" },
+        "flick": { "$ref": "#/definitions/flick" },
+        "multitap": { "$ref": "#/definitions/subkeys" },
+        "hint": { "type": "string" }
+      },
+      "anyOf": [
+        {"required": ["id"]},
+        {"required": ["sp"]},
+        {"required": ["sk"]},
+        {"required": ["flick"]},
+        {"required": ["multitap"]}
+      ],
+      "additionalProperties": false
+    },
+
+    "key-id": {
+      "type": "string",
+      "pattern": "^[TKUtku]_[a-zA-Z0-9_]+$"
+    },
+
+    "key-sp": {
+      "type": "integer",
+      "enum": [0, 1, 2, 8, 9, 10]
+    },
+
+    "key-pad": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100000
+    },
+
+    "key-width": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100000
+    },
+
+    "subkeys": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/subkey" },
+      "minItems": 1
+    },
+
+    "subkey": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/definitions/key-id" },
+        "text": { "type": "string" },
+        "layer": { "$ref": "#/definitions/layer-id" },
+        "nextlayer": { "$ref": "#/definitions/layer-id" },
+        "sp": { "$ref" : "#/definitions/key-sp" },
+        "pad": { "$ref" : "#/definitions/key-pad" },
+        "width": { "$ref" : "#/definitions/key-width" },
+        "fontsize": { "$ref": "#/definitions/fontsize-spec" },
+        "font": { "$ref": "#/definitions/font-spec" },
+        "default": { "type": "boolean" }
+      },
+      "required": ["id"],
+      "additionalProperties": false
+    },
+
+    "flick": {
+      "type": "object",
+      "patternProperties": {
+        "^(n|s|e|w|ne|nw|se|sw)$": { "$ref": "#/definitions/subkey" }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+
+    "font-spec": {
+      "type": "string"
+    },
+
+    "fontsize-spec": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/keyman-touch-layout/2.1.2/keyman-touch-layout.spec.json
+++ b/schemas/keyman-touch-layout/2.1.2/keyman-touch-layout.spec.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$ref": "#/definitions/touch-layout",
+  "$comment": "Version: 16.0",
+  "description": "A Keyman Touch Layout file, per version 16.0, loose specification that allows for legacy such as numbers as strings",
+
+  "definitions": {
+    "touch-layout": {
+      "type": "object",
+      "properties": {
+        "tablet": { "$ref": "#/definitions/platform" },
+        "phone": { "$ref": "#/definitions/platform" },
+        "desktop": { "$ref": "#/definitions/platform" }
+      }
+    },
+
+    "platform": {
+      "type": "object",
+      "properties": {
+        "font": { "$ref": "#/definitions/font-spec" },
+        "fontsize": { "$ref": "#/definitions/fontsize-spec" },
+        "layer": { "$ref": "#/definitions/layers" },
+        "displayUnderlying": { "type": "boolean" },
+        "defaultHint": { "type": "string", "enum": ["none","dot","longpress","multitap","flick","flick-n","flick-ne","flick-e","flick-se","flick-s","flick-sw","flick-w","flick-nw"] }
+      },
+      "required": ["layer"],
+      "additionalProperties": false
+    },
+
+    "layers": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/layer" }
+    },
+
+    "layer": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/definitions/layer-id" },
+        "row": { "$ref": "#/definitions/rows" }
+      },
+      "required": ["id", "row"],
+      "additionalProperties": false
+    },
+
+    "layer-id": {
+      "type": "string",
+      "pattern": "^[\\S]+$"
+    },
+
+    "rows": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/row" }
+    },
+
+    "row": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/definitions/row-id" },
+        "key": { "$ref": "#/definitions/keys" }
+      },
+      "required": ["id", "key"],
+      "additionalProperties": false
+    },
+
+    "row-id": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        }
+      ]
+    },
+
+    "keys": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/key" }
+    },
+
+    "key": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/definitions/key-id" },
+        "text": { "type": "string" },
+        "layer": { "$ref": "#/definitions/layer-id" },
+        "nextlayer": { "$ref": "#/definitions/layer-id" },
+        "fontsize": { "$ref": "#/definitions/fontsize-spec" },
+        "font": { "$ref": "#/definitions/font-spec" },
+        "dk": { "type": "string" },
+        "sp": { "$ref" : "#/definitions/numeric" },
+        "pad": { "$ref" : "#/definitions/numeric" },
+        "width": { "$ref" : "#/definitions/numeric" },
+        "sk": { "$ref": "#/definitions/subkeys" },
+        "flick": { "$ref": "#/definitions/flick" },
+        "multitap": { "$ref": "#/definitions/subkeys" },
+        "hint": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+
+    "numeric": {
+      "oneOf": [
+        { "type": "string", "pattern": "^[0-9]+(\\.?[0-9]*)$|^$" },
+        { "type": "number" }
+      ]
+    },
+
+    "key-id": {
+      "type": "string",
+      "pattern": "^[TKUtku]_[a-zA-Z0-9_]+$|^$"
+    },
+
+    "subkeys": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/subkey" }
+    },
+
+    "subkey": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/definitions/key-id" },
+        "text": { "type": "string" },
+        "layer": { "$ref": "#/definitions/layer-id" },
+        "nextlayer": { "$ref": "#/definitions/layer-id" },
+        "sp": { "$ref" : "#/definitions/numeric" },
+        "pad": { "$ref" : "#/definitions/numeric" },
+        "width": { "$ref" : "#/definitions/numeric" },
+        "fontsize": { "$ref": "#/definitions/fontsize-spec" },
+        "font": { "$ref": "#/definitions/font-spec" },
+        "dk": { "type": "string" },
+        "default": { "type": "boolean" }
+      },
+      "required": ["id"],
+      "additionalProperties": false
+    },
+
+    "flick": {
+      "type": "object",
+      "patternProperties": {
+        "^(n|s|e|w|ne|nw|se|sw)$": { "$ref": "#/definitions/subkey" }
+      },
+      "additionalProperties": false
+    },
+
+    "font-spec": {
+      "type": "string"
+    },
+
+    "fontsize-spec": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/keyman-touch-layout/README.md
+++ b/schemas/keyman-touch-layout/README.md
@@ -457,6 +457,10 @@ string") into the appropriate spec format.
 
 # .keyman-touch-layout version history
 
+## 2026-03-26 2.1.2 stable
+* Add missing 'default' property for longpress (sk) keys to clean spec. No other
+  changes.
+
 ## 2024-02-23 2.1.1 stable
 * Loosen `layer.id` requirements to any non-whitespace characters, recommend
   only alphanumeric, -, _. clean spec enforces this recommendation.


### PR DESCRIPTION
Matches property in keyman-touch-layout.spec.json. Update to version 2.1.2.

Test-bot: skip